### PR TITLE
Add detector tests

### DIFF
--- a/crates/ethernity-deeptrace/src/detectors.rs
+++ b/crates/ethernity-deeptrace/src/detectors.rs
@@ -141,7 +141,7 @@ impl SpecializedDetector for FrontrunningDetector {
         // Coleta todos os nós da árvore de chamadas
         let mut call_nodes = Vec::new();
         analysis.call_tree.traverse_preorder(|node| {
-            call_nodes.push(node);
+            call_nodes.push(node.clone());
         });
 
         // Analisa chamadas similares

--- a/crates/ethernity-deeptrace/src/trace.rs
+++ b/crates/ethernity-deeptrace/src/trace.rs
@@ -251,14 +251,14 @@ impl CallTree {
     }
 
     /// Filtra nós com base em um predicado
-    pub fn filter_nodes<F>(&self, predicate: F) -> Vec<&CallNode>
+    pub fn filter_nodes<F>(&self, mut predicate: F) -> Vec<CallNode>
     where
-        F: Fn(&CallNode) -> bool,
+        F: FnMut(&CallNode) -> bool,
     {
         let mut result = Vec::new();
         self.traverse_preorder(|node| {
             if predicate(node) {
-                result.push(node);
+                result.push(node.clone());
             }
         });
         result

--- a/crates/ethernity-deeptrace/tests/detectors_test.rs
+++ b/crates/ethernity-deeptrace/tests/detectors_test.rs
@@ -1,0 +1,242 @@
+use ethernity_deeptrace::{
+    CallTree, CallNode, CallType, TraceAnalysisResult, TokenTransfer, TokenType,
+    SandwichAttackDetector, FrontrunningDetector, ReentrancyDetector,
+    PriceManipulationDetector, SuspiciousLiquidationDetector,
+};
+use ethernity_deeptrace::SpecializedDetector;
+use ethereum_types::{Address, U256};
+
+fn addr(n: u64) -> Address {
+    Address::from_low_u64_be(n)
+}
+
+fn basic_analysis() -> TraceAnalysisResult {
+    TraceAnalysisResult {
+        call_tree: CallTree {
+            root: CallNode {
+                index: 0,
+                depth: 0,
+                call_type: CallType::Call,
+                from: addr(0),
+                to: Some(addr(1)),
+                value: U256::zero(),
+                gas: U256::zero(),
+                gas_used: U256::zero(),
+                input: Vec::new(),
+                output: Vec::new(),
+                error: None,
+                children: Vec::new(),
+            },
+        },
+        token_transfers: Vec::new(),
+        contract_creations: Vec::new(),
+        execution_path: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn test_sandwich_attack_detection() {
+    let mut analysis = basic_analysis();
+    let token = addr(10);
+    let attacker = addr(11);
+    let victim = addr(12);
+    let dex = addr(13);
+
+    let other = addr(14);
+    analysis.token_transfers = vec![
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: attacker, to: dex, amount: U256::from(100u64), token_id: None, call_index: 0 },
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: victim, to: other, amount: U256::from(50u64), token_id: None, call_index: 1 },
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: dex, to: attacker, amount: U256::from(120u64), token_id: None, call_index: 2 },
+    ];
+
+    let detector = SandwichAttackDetector::new();
+    let events = detector.detect_events(&analysis).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, "sandwich_attack");
+    assert!(events[0].addresses.contains(&attacker));
+    assert!(events[0].addresses.contains(&victim));
+}
+
+#[tokio::test]
+async fn test_frontrunning_detection() {
+    // Build call tree with two sequential calls
+    let mut root = CallNode {
+        index: 0,
+        depth: 0,
+        call_type: CallType::Call,
+        from: addr(1),
+        to: Some(addr(20)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: Vec::new(),
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+
+    let call1 = CallNode {
+        index: 1,
+        depth: 1,
+        call_type: CallType::Call,
+        from: addr(2),
+        to: Some(addr(30)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: vec![1,2,3,4],
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+    let call2 = CallNode {
+        index: 2,
+        depth: 1,
+        call_type: CallType::Call,
+        from: addr(3),
+        to: Some(addr(30)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: vec![1,2,3,4,5],
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+    let mut root_children = Vec::new();
+    root_children.push(call1.clone());
+    root_children.push(call2.clone());
+    root.children = root_children;
+
+    let analysis = TraceAnalysisResult {
+        call_tree: CallTree { root },
+        token_transfers: Vec::new(),
+        contract_creations: Vec::new(),
+        execution_path: Vec::new(),
+    };
+
+    let detector = FrontrunningDetector::new();
+    let events = detector.detect_events(&analysis).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, "frontrunning");
+}
+
+#[tokio::test]
+async fn test_reentrancy_detection() {
+    // Construct call pattern A->B -> B->A -> A->B -> B->A
+    let mut node0 = CallNode {
+        index: 0,
+        depth: 0,
+        call_type: CallType::Call,
+        from: addr(1),
+        to: Some(addr(2)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: Vec::new(),
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+
+    let mut node1 = CallNode {
+        index: 1,
+        depth: 1,
+        call_type: CallType::Call,
+        from: addr(2),
+        to: Some(addr(1)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: Vec::new(),
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+
+    let mut node2 = CallNode {
+        index: 2,
+        depth: 2,
+        call_type: CallType::Call,
+        from: addr(1),
+        to: Some(addr(2)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: Vec::new(),
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+
+    let node3 = CallNode {
+        index: 3,
+        depth: 3,
+        call_type: CallType::Call,
+        from: addr(2),
+        to: Some(addr(1)),
+        value: U256::zero(),
+        gas: U256::zero(),
+        gas_used: U256::zero(),
+        input: Vec::new(),
+        output: Vec::new(),
+        error: None,
+        children: Vec::new(),
+    };
+
+    node2.children.push(node3);
+    node1.children.push(node2);
+    node0.children.push(node1);
+
+    let analysis = TraceAnalysisResult {
+        call_tree: CallTree { root: node0 },
+        token_transfers: Vec::new(),
+        contract_creations: Vec::new(),
+        execution_path: Vec::new(),
+    };
+
+    let detector = ReentrancyDetector::new();
+    let events = detector.detect_events(&analysis).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, "reentrancy");
+}
+
+#[tokio::test]
+async fn test_price_manipulation_detection() {
+    let mut analysis = basic_analysis();
+    let token = addr(5);
+    let manipulator = addr(6);
+    let pool = addr(7);
+    let other = addr(8);
+
+    analysis.token_transfers = vec![
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: manipulator, to: pool, amount: U256::from(2_000_000u64), token_id: None, call_index: 0 },
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: pool, to: other, amount: U256::from(100u64), token_id: None, call_index: 1 },
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: other, to: manipulator, amount: U256::from(50u64), token_id: None, call_index: 2 },
+    ];
+
+    let detector = PriceManipulationDetector::new();
+    let events = detector.detect_events(&analysis).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, "price_manipulation");
+}
+
+#[tokio::test]
+async fn test_suspicious_liquidation_detection() {
+    let mut analysis = basic_analysis();
+    let token = addr(40);
+    let manipulator = addr(41);
+    let victim = addr(42);
+    let pool = addr(43);
+
+    analysis.token_transfers = vec![
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: manipulator, to: pool, amount: U256::from(200_000u64), token_id: None, call_index: 0 },
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: victim, to: pool, amount: U256::from(50u64), token_id: None, call_index: 1 },
+        TokenTransfer { token_type: TokenType::Erc20, token_address: token, from: pool, to: manipulator, amount: U256::from(150u64), token_id: None, call_index: 2 },
+    ];
+
+    let detector = SuspiciousLiquidationDetector::new();
+    let events = detector.detect_events(&analysis).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].event_type, "suspicious_liquidation");
+}


### PR DESCRIPTION
## Summary
- add async detector tests for sandwich, frontrunning, reentrancy, price manipulation and suspicious liquidation detectors
- fix compile errors in library modules to enable testing

## Testing
- `cargo test -p ethernity-deeptrace`

------
https://chatgpt.com/codex/tasks/task_e_684de5ca1ba4833297561d918d21f4fa