### PR TITLE
Improve contract type detection

### DIFF
--- a/crates/ethernity-deeptrace/src/utils.rs
+++ b/crates/ethernity-deeptrace/src/utils.rs
@@ -36,6 +36,11 @@ impl BytecodeAnalyzer {
         bytecode.windows(pattern.len()).any(|window| window == pattern)
     }
 
+    /// Conta a ocorrência de um opcode específico
+    pub fn count_opcode(bytecode: &[u8], opcode: u8) -> usize {
+        bytecode.iter().filter(|&&b| b == opcode).count()
+    }
+
     /// Analisa a complexidade do bytecode
     pub fn analyze_complexity(bytecode: &[u8]) -> BytecodeComplexity {
         let mut complexity = BytecodeComplexity::default();


### PR DESCRIPTION
## Summary
- improve bytecode analyzer with opcode counting helper
- rely on extracted function selectors when determining contract type
- detect proxy and factory contracts with better heuristics

## Testing
- `cargo test --quiet` *(fails: Unable to find libsasl2)*

------
https://chatgpt.com/codex/tasks/task_e_6850805a398c8332a59a722008644d3a