### PR TITLE
Add event detector example

### DIFF
--- a/crates/ethernity-deeptrace/examples/README.md
+++ b/crates/ethernity-deeptrace/examples/README.md
@@ -1,0 +1,15 @@
+# Exemplo de Detecção de Eventos - Rust
+
+Este exemplo demonstra como utilizar o `ethernity-deeptrace` para analisar uma transação específica e executar os detectores de eventos disponíveis.
+
+## Uso
+
+```bash
+cargo run --example event_detector -- <RPC_ENDPOINT> <TX_HASH>
+```
+
+- `<RPC_ENDPOINT>`: URL do node Ethereum (HTTP ou WebSocket).
+- `<TX_HASH>`: Hash da transação a ser analisada.
+
+O programa exibirá na saída padrão os eventos identificados para a transação informada ou avisará caso nada seja encontrado.
+

--- a/crates/ethernity-deeptrace/examples/event_detector.rs
+++ b/crates/ethernity-deeptrace/examples/event_detector.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use ethernity_core::types::TransactionHash;
+use ethernity_rpc::{EthernityRpcClient, RpcConfig};
+use ethernity_deeptrace::{DeepTraceAnalyzer, TraceAnalysisConfig, detectors::{DetectorManager, DetectedEvent}, analyzer::TraceAnalysisResult};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Leitura simples dos argumentos de linha de comando
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Uso: {} <RPC_ENDPOINT> <TX_HASH>", args[0]);
+        std::process::exit(1);
+    }
+
+    let endpoint = &args[1];
+    let tx_hash = TransactionHash::from_str(&args[2])?;
+
+    // Configura o cliente RPC
+    let rpc_config = RpcConfig { endpoint: endpoint.clone(), ..Default::default() };
+    let rpc_client = Arc::new(EthernityRpcClient::new(rpc_config).await?);
+
+    // Instancia o analisador principal
+    let analyzer = DeepTraceAnalyzer::new(rpc_client.clone(), Some(TraceAnalysisConfig::default()));
+
+    println!("🔍 Analisando transação {tx_hash:?}...");
+    let tx_analysis = analyzer.analyze_transaction(tx_hash).await?;
+
+    // Constrói o resultado de análise para os detectores
+    let analysis_result = TraceAnalysisResult {
+        call_tree: tx_analysis.call_tree.clone(),
+        token_transfers: tx_analysis.token_transfers.clone(),
+        contract_creations: tx_analysis.contract_creations.clone(),
+        execution_path: tx_analysis.execution_path.clone(),
+    };
+
+    // Executa todos os detectores disponíveis
+    let detector_manager = DetectorManager::new();
+    let events = detector_manager.detect_all(&analysis_result).await?;
+
+    if events.is_empty() {
+        println!("Nenhum evento suspeito detectado para a transação {tx_hash:?}.");
+    } else {
+        println!("Eventos detectados:");
+        for DetectedEvent { event_type, description, confidence, .. } in events {
+            println!("- {event_type}: {description} (confiança {:.2}%)", confidence * 100.0);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a Rust example to test blockchain event detectors
- document how to run the new example

## Testing
- `cargo test --quiet` *(fails: libsasl2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852db1dbfbc83329acb7cea267e1d37