### PR TITLE
Add pattern detector example

### DIFF
--- a/crates/ethernity-deeptrace/examples/README.md
+++ b/crates/ethernity-deeptrace/examples/README.md
@@ -1,15 +1,20 @@
-# Exemplo de Detecção de Eventos - Rust
+# Exemplos - Rust
 
-Este exemplo demonstra como utilizar o `ethernity-deeptrace` para analisar uma transação específica e executar os detectores de eventos disponíveis.
+Aqui estão exemplos de como utilizar o `ethernity-deeptrace` para analisar transações Ethereum.
 
-## Uso
+## Detecção de Eventos
 
 ```bash
 cargo run --example event_detector -- <RPC_ENDPOINT> <TX_HASH>
 ```
 
-- `<RPC_ENDPOINT>`: URL do node Ethereum (HTTP ou WebSocket).
-- `<TX_HASH>`: Hash da transação a ser analisada.
+Analisa a transação indicada e executa os detectores de eventos disponíveis, mostrando as ocorrências encontradas (reentrancy, sandwich attack etc.).
 
-O programa exibirá na saída padrão os eventos identificados para a transação informada ou avisará caso nada seja encontrado.
+## Detecção de Padrões
+
+```bash
+cargo run --example pattern_detector -- <RPC_ENDPOINT> <TX_HASH>
+```
+
+Executa a análise completa e lista os padrões DeFi (flash loans, arbitragem, rug pull e outros) detectados para a transação informada.
 

--- a/crates/ethernity-deeptrace/examples/pattern_detector.rs
+++ b/crates/ethernity-deeptrace/examples/pattern_detector.rs
@@ -1,0 +1,54 @@
+use std::env;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use ethernity_core::traits::RpcProvider;
+use ethernity_core::types::TransactionHash;
+use ethernity_rpc::{EthernityRpcClient, RpcConfig};
+use ethernity_deeptrace::{DeepTraceAnalyzer, TraceAnalysisConfig};
+
+/// Analisa uma transação específica e exibe os padrões detectados.
+async fn analyze_patterns(tx_hash: TransactionHash, rpc: Arc<dyn RpcProvider>) -> anyhow::Result<()> {
+    // Inicializa o analisador com configurações padrão
+    let analyzer = DeepTraceAnalyzer::new(rpc, Some(TraceAnalysisConfig::default()));
+
+    // Processa a transação fornecida
+    let result = analyzer.analyze_transaction(tx_hash).await?;
+
+    // Exibe os padrões encontrados de maneira clara
+    if result.detected_patterns.is_empty() {
+        println!("Nenhum padrão encontrado para {tx_hash:?}");
+    } else {
+        println!("Padrões detectados para {tx_hash:?}:");
+        for pattern in result.detected_patterns {
+            println!(
+                "- {:?}: {} (confiança {:.2}%)",
+                pattern.pattern_type,
+                pattern.description,
+                pattern.confidence * 100.0
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Leitura simples dos argumentos da linha de comando
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Uso: {} <RPC_ENDPOINT> <TX_HASH>", args[0]);
+        std::process::exit(1);
+    }
+
+    let endpoint = &args[1];
+    let tx_hash = TransactionHash::from_str(&args[2])?;
+
+    // Configura o cliente RPC informado
+    let rpc_config = RpcConfig { endpoint: endpoint.clone(), ..Default::default() };
+    let rpc_client = Arc::new(EthernityRpcClient::new(rpc_config).await?);
+
+    // Executa a análise de padrões
+    analyze_patterns(tx_hash, rpc_client).await
+}
+


### PR DESCRIPTION
## Summary
- add pattern_detector example for checking DeFi patterns
- document how to run the new example along with the existing one

## Testing
- `cargo test --workspace` *(fails: libsasl2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852f8062a748332807834ca5d179834