### PR TITLE
Add RpcMethod enum for finder options

### DIFF
--- a/crates/ethernity-finder/README.md
+++ b/crates/ethernity-finder/README.md
@@ -5,6 +5,14 @@ Ferramenta para localizar nodes Ethereum utilizando a API do Shodan.
 O objetivo é buscar endpoints RPC expostos, validar o `chainId` e verificar se
 métodos RPC internos específicos estão disponíveis.
 
+Os métodos aceitos são representados pelo enum `RpcMethod`, que inclui:
+
+- `debug_traceTransaction`
+- `admin_nodeInfo`
+- `admin_peers`
+- `txpool_content`
+- `trace_block`
+
 A crate expõe um trait `NodeFinder` com implementação padrão `ShodanFinder` que
 pode ser reutilizada pelos demais módulos do projeto.
 

--- a/crates/ethernity-finder/examples/README.md
+++ b/crates/ethernity-finder/examples/README.md
@@ -7,3 +7,11 @@ cargo run --example find_nodes -- <CHAIN_ID> <LIMIT|all> <METHOD1,METHOD2,...>
 ```
 
 O limite pode ser um número ou `all` para buscar todos os nodes válidos. A lista de métodos deve ser separada por vírgulas.
+
+Métodos suportados:
+
+- `debug_traceTransaction`
+- `admin_nodeInfo`
+- `admin_peers`
+- `txpool_content`
+- `trace_block`

--- a/crates/ethernity-finder/examples/find_nodes.rs
+++ b/crates/ethernity-finder/examples/find_nodes.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use ethernity_finder::{FinderOptions, NodeFinder, ShodanFinder};
+use ethernity_finder::{FinderOptions, NodeFinder, ShodanFinder, RpcMethod};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -18,8 +18,20 @@ async fn main() -> anyhow::Result<()> {
     };
     let methods = args[3]
         .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+        .filter_map(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                match trimmed.parse::<RpcMethod>() {
+                    Ok(m) => Some(m),
+                    Err(e) => {
+                        eprintln!("Ignorando método desconhecido '{}': {}", trimmed, e);
+                        None
+                    }
+                }
+            }
+        })
         .collect::<Vec<_>>();
 
     let finder = ShodanFinder::new();


### PR DESCRIPTION
## Summary
- add `RpcMethod` enum to represent supported RPC methods
- update `FinderOptions` and related types to use the enum
- parse enum values in the `find_nodes` example
- document supported methods in README files

## Testing
- `cargo test --workspace` *(fails: could not find libsasl2)*

------
https://chatgpt.com/codex/tasks/task_e_685386c5f1e88332912d53821c9a095e