### PR TITLE
Refatora módulo trace em submódulos

### DIFF
--- a/crates/ethernity-deeptrace/src/trace/detector.rs
+++ b/crates/ethernity-deeptrace/src/trace/detector.rs
@@ -1,0 +1,10 @@
+use async_trait::async_trait;
+
+use super::CallTrace;
+
+/// Detector de padrões em traces
+#[async_trait]
+pub trait TraceDetector: Send + Sync {
+    /// Detecta padrões em um trace
+    async fn detect(&self, trace: &CallTrace) -> Result<Vec<crate::DetectedPattern>, ()>;
+}

--- a/crates/ethernity-deeptrace/src/trace/mod.rs
+++ b/crates/ethernity-deeptrace/src/trace/mod.rs
@@ -1,0 +1,7 @@
+mod detector;
+mod tree;
+mod types;
+
+pub use detector::TraceDetector;
+pub use tree::{CallNode, CallTree};
+pub use types::{CallTrace, CallType};

--- a/crates/ethernity-deeptrace/src/trace/tree.rs
+++ b/crates/ethernity-deeptrace/src/trace/tree.rs
@@ -1,54 +1,8 @@
-use async_trait::async_trait;
+use std::str::FromStr;
 use ethereum_types::{Address, U256};
 use ethernity_core::Error;
-use std::str::FromStr;
+use super::{CallTrace, CallType};
 
-/// Estrutura de trace de chamada
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct CallTrace {
-    pub from: String,
-    pub gas: String,
-    #[serde(rename = "gasUsed")]
-    pub gas_used: String,
-    pub to: String,
-    pub input: String,
-    pub output: String,
-    pub value: String,
-    pub error: Option<String>,
-    pub calls: Option<Vec<CallTrace>>,
-    #[serde(rename = "type")]
-    pub call_type: Option<String>,
-}
-
-/// Tipo de chamada
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CallType {
-    Call,
-    StaticCall,
-    DelegateCall,
-    CallCode,
-    Create,
-    Create2,
-    SelfDestruct,
-    Unknown,
-}
-
-impl From<&str> for CallType {
-    fn from(s: &str) -> Self {
-        match s {
-            "CALL" => CallType::Call,
-            "STATICCALL" => CallType::StaticCall,
-            "DELEGATECALL" => CallType::DelegateCall,
-            "CALLCODE" => CallType::CallCode,
-            "CREATE" => CallType::Create,
-            "CREATE2" => CallType::Create2,
-            "SELFDESTRUCT" => CallType::SelfDestruct,
-            _ => CallType::Unknown,
-        }
-    }
-}
-
-/// Árvore de chamadas
 #[derive(Debug, Clone)]
 pub struct CallTree {
     pub root: CallNode,
@@ -331,9 +285,3 @@ impl CallTree {
     }
 }
 
-/// Detector de padrões em traces
-#[async_trait]
-pub trait TraceDetector: Send + Sync {
-    /// Detecta padrões em um trace
-    async fn detect(&self, trace: &CallTrace) -> Result<Vec<crate::DetectedPattern>, ()>;
-}

--- a/crates/ethernity-deeptrace/src/trace/types.rs
+++ b/crates/ethernity-deeptrace/src/trace/types.rs
@@ -1,0 +1,46 @@
+use serde::Deserialize;
+
+/// Estrutura de trace de chamada
+#[derive(Debug, Clone, Deserialize)]
+pub struct CallTrace {
+    pub from: String,
+    pub gas: String,
+    #[serde(rename = "gasUsed")]
+    pub gas_used: String,
+    pub to: String,
+    pub input: String,
+    pub output: String,
+    pub value: String,
+    pub error: Option<String>,
+    pub calls: Option<Vec<CallTrace>>,
+    #[serde(rename = "type")]
+    pub call_type: Option<String>,
+}
+
+/// Tipo de chamada
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallType {
+    Call,
+    StaticCall,
+    DelegateCall,
+    CallCode,
+    Create,
+    Create2,
+    SelfDestruct,
+    Unknown,
+}
+
+impl From<&str> for CallType {
+    fn from(s: &str) -> Self {
+        match s {
+            "CALL" => CallType::Call,
+            "STATICCALL" => CallType::StaticCall,
+            "DELEGATECALL" => CallType::DelegateCall,
+            "CALLCODE" => CallType::CallCode,
+            "CREATE" => CallType::Create,
+            "CREATE2" => CallType::Create2,
+            "SELFDESTRUCT" => CallType::SelfDestruct,
+            _ => CallType::Unknown,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- reorganize deeptrace `trace` with SRP in mind
- split call tree logic into `trace/tree.rs`
- define data types in `trace/types.rs`
- keep pattern detection trait in `trace/detector.rs`
- re-export items via `trace/mod.rs`

## Testing
- `cargo check -p ethernity-deeptrace`
- `cargo test -p ethernity-deeptrace -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_685739c06f588332beb5dce92a6bcbf6