### PR TITLE
Increase analyzer integration test coverage

### DIFF
--- a/crates/ethernity-deeptrace/src/analyzer/mod.rs
+++ b/crates/ethernity-deeptrace/src/analyzer/mod.rs
@@ -104,4 +104,97 @@ mod tests {
         assert_eq!(result.contract_creations.len(), 0);
         assert_eq!(result.execution_path.len(), 1);
     }
+
+    struct MockRpcSuccess;
+
+    #[async_trait]
+    impl ethernity_core::traits::RpcProvider for MockRpcSuccess {
+        async fn get_transaction_trace(&self, _tx: ethernity_core::types::TransactionHash) -> ethernity_core::error::Result<Vec<u8>> { Ok(vec![]) }
+        async fn get_transaction_receipt(&self, _tx: ethernity_core::types::TransactionHash) -> ethernity_core::error::Result<Vec<u8>> { Ok(vec![]) }
+        async fn get_code(&self, _address: ethereum_types::Address) -> ethernity_core::error::Result<Vec<u8>> {
+            Ok(vec![0x63,0x70,0xa0,0x82,0x31,0x00,0x00,0x63,0xa9,0x05,0x9c,0xbb,0x00,0x00])
+        }
+        async fn call(&self, _to: ethereum_types::Address, _data: Vec<u8>) -> ethernity_core::error::Result<Vec<u8>> { Ok(vec![]) }
+        async fn get_block_number(&self) -> ethernity_core::error::Result<u64> { Ok(0) }
+    }
+
+    struct MockRpcFail;
+
+    #[async_trait]
+    impl ethernity_core::traits::RpcProvider for MockRpcFail {
+        async fn get_transaction_trace(&self, _tx: ethernity_core::types::TransactionHash) -> ethernity_core::error::Result<Vec<u8>> { Ok(vec![]) }
+        async fn get_transaction_receipt(&self, _tx: ethernity_core::types::TransactionHash) -> ethernity_core::error::Result<Vec<u8>> { Ok(vec![]) }
+        async fn get_code(&self, _address: ethereum_types::Address) -> ethernity_core::error::Result<Vec<u8>> {
+            Err(ethernity_core::Error::Other("fail".into()))
+        }
+        async fn call(&self, _to: ethereum_types::Address, _data: Vec<u8>) -> ethernity_core::error::Result<Vec<u8>> { Ok(vec![]) }
+        async fn get_block_number(&self) -> ethernity_core::error::Result<u64> { Ok(0) }
+    }
+
+    fn creation_trace() -> CallTrace {
+        CallTrace {
+            from: "0x0000000000000000000000000000000000000001".into(),
+            gas: "0".into(),
+            gas_used: "0".into(),
+            to: "0x0000000000000000000000000000000000000002".into(),
+            input: "0x".into(),
+            output: "0x".into(),
+            value: "0".into(),
+            error: None,
+            calls: Some(vec![CallTrace {
+                from: "0x0000000000000000000000000000000000000001".into(),
+                gas: "0".into(),
+                gas_used: "0".into(),
+                to: "0x0000000000000000000000000000000000000100".into(),
+                input: "0x".into(),
+                output: "0x".into(),
+                value: "0".into(),
+                error: None,
+                calls: None,
+                call_type: Some("CREATE".into()),
+            }]),
+            call_type: Some("CALL".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_analyze_full_integration() {
+        let ctx = AnalysisContext {
+            tx_hash: H256::zero(),
+            block_number: 0,
+            timestamp: chrono::Utc::now(),
+            rpc_client: Arc::new(MockRpcSuccess),
+            memory_manager: Arc::new(MemoryManager::new()),
+            config: TraceAnalysisConfig::default(),
+        };
+        let analyzer = TraceAnalyzer::new(ctx);
+        let trace = creation_trace();
+        let transfer_sig = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+        let receipt = json!({"logs": [{
+            "address": "0x0000000000000000000000000000000000000001",
+            "topics": [transfer_sig, "0x0000000000000000000000000000000000000002", "0x0000000000000000000000000000000000000003"],
+            "data": "0x01"
+        }]});
+        let result = analyzer.analyze(&trace, &receipt).await.unwrap();
+        assert_eq!(result.token_transfers.len(), 1);
+        assert_eq!(result.contract_creations.len(), 1);
+        assert_eq!(result.execution_path.len(), 2);
+        assert_eq!(result.call_tree.root.call_type, CallType::Call);
+    }
+
+    #[tokio::test]
+    async fn test_analyze_propagates_contract_creation_error() {
+        let ctx = AnalysisContext {
+            tx_hash: H256::zero(),
+            block_number: 0,
+            timestamp: chrono::Utc::now(),
+            rpc_client: Arc::new(MockRpcFail),
+            memory_manager: Arc::new(MemoryManager::new()),
+            config: TraceAnalysisConfig::default(),
+        };
+        let analyzer = TraceAnalyzer::new(ctx);
+        let trace = creation_trace();
+        let receipt = json!({"logs": []});
+        assert!(analyzer.analyze(&trace, &receipt).await.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- add additional integration tests for `TraceAnalyzer::analyze`
- cover success path with contract creation and token transfers
- cover error propagation when contract creation fails

## Testing
- `cargo test -p ethernity-deeptrace -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685794e1f9a083329bd22337ed6d853f