### PR TITLE
Add SmartCache eviction test

### DIFF
--- a/crates/ethernity-deeptrace/tests/cache_eviction.rs
+++ b/crates/ethernity-deeptrace/tests/cache_eviction.rs
@@ -1,0 +1,22 @@
+use ethernity_deeptrace::SmartCache;
+use std::time::Duration;
+
+#[tokio::test]
+async fn test_smart_cache_overwrite_counts_eviction() {
+    let cache = SmartCache::<&'static str, i32>::new(2, Duration::from_millis(50));
+
+    cache.insert("x", 1);
+    assert_eq!(cache.get(&"x"), Some(1));
+
+    // overwriting same key should increment eviction counter
+    cache.insert("x", 2);
+    assert_eq!(cache.get(&"x"), Some(2));
+
+    let stats = cache.stats();
+    assert_eq!(stats.inserts, 2);
+    assert_eq!(stats.evictions, 1);
+    // two successful gets above
+    assert_eq!(stats.hits, 2);
+    assert_eq!(stats.misses, 0);
+    assert_eq!(stats.expirations, 0);
+}


### PR DESCRIPTION
## Summary
- add a new integration test ensuring overwriting a key in `SmartCache` counts as an eviction

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6857951115f08332b4408a47d68dbf2a