### PR TITLE
Add MEV detector crate with transaction tagger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethernity-detector-mev"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ethereum-types",
+ "ethernity-core",
+ "ethers",
+ "hex",
+ "lru 0.10.1",
+ "parking_lot",
+ "serde",
+ "tiny-keccak",
+ "tokio",
+]
+
+[[package]]
 name = "ethernity-finder"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/ethernity-rpc",
     "crates/ethernity-finder",
     "crates/ethernity-fingerprint",
+    "crates/ethernity-detector-mev",
 ]
 
 [workspace.package]

--- a/crates/ethernity-detector-mev/Cargo.toml
+++ b/crates/ethernity-detector-mev/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ethernity-detector-mev"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Detecção passiva de oportunidades MEV em transações Ethereum"
+license.workspace = true
+
+[dependencies]
+ethernity-core = { path = "../ethernity-core" }
+lru = { workspace = true }
+parking_lot = { workspace = true }
+async-trait = { workspace = true }
+ethers = { workspace = true }
+ethereum-types = { workspace = true }
+tiny-keccak = { version = "2.0", features = ["keccak"] }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+hex = "0.4"
+tokio = { workspace = true, features = ["full"] }

--- a/crates/ethernity-detector-mev/README.md
+++ b/crates/ethernity-detector-mev/README.md
@@ -1,0 +1,3 @@
+# ethernity-detector-mev
+
+Crate dedicada à detecção passiva de oportunidades de MEV a partir de transações observadas na mempool. O módulo inicial `TxNatureTagger` realiza inferência estática da natureza de uma transação analisando o `calldata` e o bytecode do endereço de destino. O resultado é um conjunto de tags e informações resumidas que podem ser usadas por outros componentes do sistema para agrupamento e priorização.

--- a/crates/ethernity-detector-mev/src/lib.rs
+++ b/crates/ethernity-detector-mev/src/lib.rs
@@ -1,0 +1,10 @@
+/*!
+ * Ethernity Detector MEV
+ *
+ * Módulo inicial `TxNatureTagger` para inferência estática
+ * de transações Ethereum observadas na mempool.
+ */
+
+mod tx_nature_tagger;
+
+pub use tx_nature_tagger::*;

--- a/crates/ethernity-detector-mev/src/tx_nature_tagger.rs
+++ b/crates/ethernity-detector-mev/src/tx_nature_tagger.rs
@@ -1,0 +1,151 @@
+use ethernity_core::{error::Result, traits::RpcProvider, types::TransactionHash};
+use ethereum_types::Address;
+use lru::LruCache;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+/// Componentes que contribuem para o cálculo de confiança.
+#[derive(Debug, Clone, Default)]
+pub struct ConfidenceComponents {
+    pub abi_match: f64,
+    pub structure: f64,
+    pub path: f64,
+}
+
+/// Resultado da inferência da natureza da transação.
+#[derive(Debug, Clone, Default)]
+pub struct TxNature {
+    pub tx_hash: TransactionHash,
+    pub tags: Vec<String>,
+    pub token_paths: Vec<Address>,
+    pub targets: Vec<Address>,
+    pub confidence: f64,
+    pub confidence_components: ConfidenceComponents,
+    pub extracted_fallback: bool,
+    pub ambiguous_execution_path: bool,
+    pub reachable_via_dispatcher: bool,
+    pub path_inference_failed: bool,
+}
+
+/// Tagger responsável por inferir a natureza de uma transação Ethereum.
+pub struct TxNatureTagger<P> {
+    provider: P,
+    selectors: HashMap<[u8; 4], Vec<String>>,
+    code_cache: Mutex<LruCache<Address, Vec<u8>>>,
+}
+
+impl<P> TxNatureTagger<P> {
+    /// Cria uma nova instância de tagger.
+    pub fn new(provider: P) -> Self {
+        let mut selectors = HashMap::new();
+        selectors.insert(
+            [0x38, 0xed, 0x17, 0x39],
+            vec!["swap-v2".to_string(), "router-call".to_string()],
+        );
+        selectors.insert(
+            [0x18, 0xcb, 0xaf, 0x95],
+            vec!["swap-v3".to_string(), "router-call".to_string()],
+        );
+        selectors.insert(
+            [0xa9, 0x05, 0x9c, 0xbb],
+            vec!["transfer".to_string(), "token-move".to_string()],
+        );
+
+        Self {
+            provider,
+            selectors,
+            code_cache: Mutex::new(LruCache::new(NonZeroUsize::new(1024).unwrap())),
+        }
+    }
+}
+
+impl<P: RpcProvider + Send + Sync> TxNatureTagger<P> {
+    /// Analisa uma transação e retorna sua provável natureza.
+    pub async fn analyze(
+        &self,
+        to: Address,
+        input: &[u8],
+        tx_hash: TransactionHash,
+    ) -> Result<TxNature> {
+        // Seleciona os 4 primeiros bytes do calldata
+        let selector = if input.len() >= 4 {
+            Some([input[0], input[1], input[2], input[3]])
+        } else {
+            None
+        };
+
+        let mut result = TxNature {
+            tx_hash,
+            targets: vec![to],
+            ..Default::default()
+        };
+
+        if let Some(sel) = selector {
+            if let Some(tags) = self.selectors.get(&sel) {
+                result.tags.extend(tags.clone());
+                result.confidence_components.abi_match = 0.9;
+            } else {
+                result.confidence_components.abi_match = 0.1;
+            }
+        }
+
+        // Recupera bytecode do contrato destino usando cache
+        let code = self.get_code_cached(to).await?;
+
+        // Heurística simples para delegação
+        if code.iter().any(|&b| b == 0xf4u8) {
+            result.tags.push("proxy-call".to_string());
+            result.confidence_components.structure = 0.7;
+        } else {
+            result.confidence_components.structure = 0.5;
+        }
+
+        // Extração de possíveis endereços após o seletor
+        if input.len() > 4 {
+            let mut paths = Vec::new();
+            for chunk in input[4..].chunks(32) {
+                if chunk.len() == 32 {
+                    let addr = Address::from_slice(&chunk[12..32]);
+                    if addr != Address::zero() {
+                        paths.push(addr);
+                    }
+                }
+            }
+            if !paths.is_empty() {
+                result.token_paths = paths;
+                result.extracted_fallback = true;
+                result.confidence_components.path = 0.5;
+            } else {
+                result.path_inference_failed = true;
+            }
+        } else {
+            result.path_inference_failed = true;
+        }
+
+        result.confidence = (
+            result.confidence_components.abi_match
+                + result.confidence_components.structure
+                + result.confidence_components.path
+        ) / 3.0;
+
+        Ok(result)
+    }
+
+    async fn get_code_cached(&self, address: Address) -> Result<Vec<u8>> {
+        {
+            let mut cache = self.code_cache.lock();
+            if let Some(code) = cache.get(&address) {
+                return Ok(code.clone());
+            }
+        }
+
+        let code = self.provider.get_code(address).await?;
+        {
+            let mut cache = self.code_cache.lock();
+            cache.put(address, code.clone());
+        }
+        Ok(code)
+    }
+}
+

--- a/crates/ethernity-detector-mev/tests/tagger_basic.rs
+++ b/crates/ethernity-detector-mev/tests/tagger_basic.rs
@@ -1,0 +1,43 @@
+use ethernity_detector_mev::{TxNatureTagger};
+use ethernity_core::{traits::RpcProvider, error::Result, types::TransactionHash};
+use ethereum_types::{Address, H256};
+use async_trait::async_trait;
+
+struct DummyProvider;
+
+#[async_trait]
+impl RpcProvider for DummyProvider {
+    async fn get_transaction_trace(&self, _tx_hash: TransactionHash) -> Result<Vec<u8>> {
+        Ok(vec![])
+    }
+
+    async fn get_transaction_receipt(&self, _tx_hash: TransactionHash) -> Result<Vec<u8>> {
+        Ok(vec![])
+    }
+
+    async fn get_code(&self, _address: Address) -> Result<Vec<u8>> {
+        // bytecode simples sem delegatecall
+        Ok(vec![0x60, 0x00, 0x60, 0x00, 0x56])
+    }
+
+    async fn call(&self, _to: Address, _data: Vec<u8>) -> Result<Vec<u8>> {
+        Ok(vec![])
+    }
+
+    async fn get_block_number(&self) -> Result<u64> {
+        Ok(0)
+    }
+}
+
+#[tokio::test]
+async fn detect_swap_v2() {
+    let provider = DummyProvider;
+    let tagger = TxNatureTagger::new(provider);
+    // calldata para swapExactTokensForTokens (selector 0x38ed1739)
+    let data = hex::decode("38ed173900000000000000000000000000000000000000000000000000000000000001").unwrap();
+    let to = Address::repeat_byte(0x11);
+    let tx_hash = H256::repeat_byte(0x22);
+
+    let res = tagger.analyze(to, &data, tx_hash).await.unwrap();
+    assert!(res.tags.contains(&"swap-v2".to_string()));
+}


### PR DESCRIPTION
## Summary
- implement new crate `ethernity-detector-mev`
- introduce `TxNatureTagger` with basic selector and bytecode heuristics
- add unit test for tag detection
- register new crate in workspace

## Testing
- `cargo test -p ethernity-detector-mev`
- `cargo check --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6858c0d841548332aee5bc6cbe4ef7f6