### PR TITLE
Add StateCacheManager module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ name = "ethernity-detector-mev"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "ethereum-types",
  "ethernity-core",
  "ethers",

--- a/crates/ethernity-detector-mev/Cargo.toml
+++ b/crates/ethernity-detector-mev/Cargo.toml
@@ -15,6 +15,7 @@ ethers = { workspace = true }
 ethereum-types = { workspace = true }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde = { workspace = true, features = ["derive"] }
+chrono = { workspace = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/ethernity-detector-mev/src/lib.rs
+++ b/crates/ethernity-detector-mev/src/lib.rs
@@ -8,7 +8,9 @@
 mod tx_nature_tagger;
 mod tx_aggregator;
 mod state_impact_evaluator;
+mod state_cache_manager;
 
 pub use tx_nature_tagger::*;
 pub use tx_aggregator::*;
 pub use state_impact_evaluator::*;
+pub use state_cache_manager::*;

--- a/crates/ethernity-detector-mev/src/state_cache_manager.rs
+++ b/crates/ethernity-detector-mev/src/state_cache_manager.rs
@@ -1,0 +1,175 @@
+use crate::state_impact_evaluator::StateSnapshot;
+use crate::tx_aggregator::TxGroup;
+use ethernity_core::error::{Error, Result};
+use ethernity_core::traits::RpcProvider;
+use ethereum_types::{Address, H256, U256};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+
+/// Perfil de granularidade para snapshot de estado
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SnapshotProfile {
+    Basic,
+    Extended,
+    Deep,
+}
+
+impl SnapshotProfile {
+    fn as_str(&self) -> &'static str {
+        match self {
+            SnapshotProfile::Basic => "basic",
+            SnapshotProfile::Extended => "extended",
+            SnapshotProfile::Deep => "deep",
+        }
+    }
+}
+
+impl From<&str> for SnapshotProfile {
+    fn from(value: &str) -> Self {
+        match value {
+            "extended" => SnapshotProfile::Extended,
+            "deep" => SnapshotProfile::Deep,
+            _ => SnapshotProfile::Basic,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedSnapshot {
+    snapshot: StateSnapshot,
+    block_number: u64,
+    timestamp: u64,
+    profile: SnapshotProfile,
+    group_origin: Vec<H256>,
+}
+
+/// Gerenciador de cache de snapshots de estado on-chain
+pub struct StateCacheManager<P> {
+    provider: P,
+    cache: Mutex<HashMap<(Address, u64, SnapshotProfile), CachedSnapshot>>, // chave (target, blockNumber, profile)
+    history: Mutex<HashMap<Address, Vec<CachedSnapshot>>>,
+}
+
+impl<P> StateCacheManager<P> {
+    /// Cria um novo gerenciador a partir de um provider RPC
+    pub fn new(provider: P) -> Self {
+        Self {
+            provider,
+            cache: Mutex::new(HashMap::new()),
+            history: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<P: RpcProvider> StateCacheManager<P> {
+    /// Realiza snapshot dos targets provenientes do TxAggregator
+    pub async fn snapshot_groups(
+        &self,
+        groups: &HashMap<H256, TxGroup>,
+        block_number: u64,
+        profile: SnapshotProfile,
+    ) -> Result<()> {
+        // deduplicação target -> grupos
+        let mut dedup: HashMap<Address, Vec<H256>> = HashMap::new();
+        for (gid, g) in groups {
+            for t in &g.targets {
+                dedup.entry(*t).or_default().push(*gid);
+            }
+        }
+        for (target, origin) in dedup {
+            if self
+                .cache
+                .lock()
+                .contains_key(&(target, block_number, profile))
+            {
+                continue;
+            }
+            let mut snap = self.fetch_v2_snapshot(target).await?;
+            snap.state_lag_blocks = 1; // pending+1
+            self.store_snapshot(target, block_number, profile, snap, origin);
+        }
+        Ok(())
+    }
+
+    fn store_snapshot(
+        &self,
+        target: Address,
+        block_number: u64,
+        profile: SnapshotProfile,
+        snapshot: StateSnapshot,
+        origin: Vec<H256>,
+    ) {
+        let entry = CachedSnapshot {
+            snapshot: snapshot.clone(),
+            block_number,
+            timestamp: chrono::Utc::now().timestamp() as u64,
+            profile,
+            group_origin: origin,
+        };
+        let key = (target, block_number, profile);
+        {
+            let mut c = self.cache.lock();
+            c.insert(key, entry.clone());
+        }
+        let mut h = self.history.lock();
+        let hist = h.entry(target).or_default();
+        hist.push(entry.clone());
+        // mantém apenas os últimos 3 blocos
+        while hist.len() > 3 {
+            hist.remove(0);
+        }
+        // calcula volatilidade simples
+        if hist.len() >= 2 {
+            let prev = &hist[hist.len() - 2];
+            let curr = &hist[hist.len() - 1];
+            let delta = if prev.snapshot.reserve_in != 0.0 {
+                ((curr.snapshot.reserve_in - prev.snapshot.reserve_in).abs()
+                    / prev.snapshot.reserve_in)
+                    * 100.0
+            } else {
+                0.0
+            };
+            if delta > 5.0 {
+                // atualiza flag
+                let mut c = self.cache.lock();
+                if let Some(e) = c.get_mut(&key) {
+                    e.snapshot.volatility_flag = true;
+                }
+            }
+        }
+    }
+
+    async fn fetch_v2_snapshot(&self, target: Address) -> Result<StateSnapshot> {
+        // selector getReserves()
+        let data = vec![0x09, 0x02, 0xf1, 0xac];
+        let out = self.provider.call(target, data).await?;
+        if out.len() < 64 {
+            return Err(Error::DecodeError("invalid getReserves response".into()));
+        }
+        let r0 = U256::from_big_endian(&out[0..32]);
+        let r1 = U256::from_big_endian(&out[32..64]);
+        let reserve0 = r0.low_u128() as f64;
+        let reserve1 = r1.low_u128() as f64;
+        Ok(StateSnapshot {
+            reserve_in: reserve0,
+            reserve_out: reserve1,
+            sqrt_price_x96: None,
+            liquidity: None,
+            state_lag_blocks: 0,
+            reorg_risk_level: "low".to_string(),
+            volatility_flag: false,
+        })
+    }
+
+    /// Recupera snapshot armazenado
+    pub fn get_state(
+        &self,
+        target: Address,
+        block_number: u64,
+        profile: SnapshotProfile,
+    ) -> Option<StateSnapshot> {
+        let c = self.cache.lock();
+        c.get(&(target, block_number, profile)).map(|e| e.snapshot.clone())
+    }
+}
+

--- a/crates/ethernity-detector-mev/src/state_impact_evaluator.rs
+++ b/crates/ethernity-detector-mev/src/state_impact_evaluator.rs
@@ -1,4 +1,4 @@
-use crate::tx_aggregator::{AnnotatedTx, TxGroup};
+use crate::tx_aggregator::TxGroup;
 use ethernity_core::types::TransactionHash;
 use ethereum_types::{Address, H256};
 use serde::{Deserialize, Serialize};

--- a/crates/ethernity-detector-mev/tests/state_cache_basic.rs
+++ b/crates/ethernity-detector-mev/tests/state_cache_basic.rs
@@ -1,0 +1,54 @@
+use ethernity_detector_mev::{AnnotatedTx, TxAggregator, StateCacheManager, SnapshotProfile};
+use ethernity_core::{traits::RpcProvider, error::Result, types::TransactionHash};
+use ethereum_types::{Address, H256, U256};
+use async_trait::async_trait;
+
+struct DummyProvider;
+
+#[async_trait]
+impl RpcProvider for DummyProvider {
+    async fn get_transaction_trace(&self, _tx_hash: TransactionHash) -> Result<Vec<u8>> { Ok(vec![]) }
+    async fn get_transaction_receipt(&self, _tx_hash: TransactionHash) -> Result<Vec<u8>> { Ok(vec![]) }
+    async fn get_code(&self, _address: Address) -> Result<Vec<u8>> { Ok(vec![]) }
+    async fn call(&self, _to: Address, _data: Vec<u8>) -> Result<Vec<u8>> {
+        let mut out = vec![0u8; 96];
+        U256::from(1000u64).to_big_endian(&mut out[0..32]);
+        U256::from(1000u64).to_big_endian(&mut out[32..64]);
+        Ok(out)
+    }
+    async fn get_block_number(&self) -> Result<u64> { Ok(100) }
+}
+
+#[tokio::test]
+async fn cache_basic_snapshot() {
+    let provider = DummyProvider;
+    let manager = StateCacheManager::new(provider);
+
+    let mut aggr = TxAggregator::new();
+    let token_paths = vec![Address::repeat_byte(0x01), Address::repeat_byte(0x02)];
+    let targets = vec![Address::repeat_byte(0xaa)];
+    let tags = vec!["swap-v2".to_string()];
+    let tx = AnnotatedTx {
+        tx_hash: H256::repeat_byte(0x10),
+        token_paths: token_paths.clone(),
+        targets: targets.clone(),
+        tags: tags.clone(),
+        first_seen: 1,
+        gas_price: 10.0,
+        max_priority_fee_per_gas: None,
+        confidence: 0.9,
+    };
+    aggr.add_tx(tx);
+
+    manager
+        .snapshot_groups(aggr.groups(), 101, SnapshotProfile::Basic)
+        .await
+        .unwrap();
+
+    let target = Address::repeat_byte(0xaa);
+    let snap = manager
+        .get_state(target, 101, SnapshotProfile::Basic)
+        .expect("snapshot missing");
+    assert_eq!(snap.reserve_in, 1000.0);
+    assert!(!snap.volatility_flag);
+}


### PR DESCRIPTION
## Summary
- implement `StateCacheManager` to cache on-chain state snapshots
- expose new module in library exports
- add chrono dependency
- clean unused import in `StateImpactEvaluator`
- add tests covering basic caching functionality

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6858c71f741c83328f86fd17a2de9067