### PR TITLE
Introduce bounded context event flow

### DIFF
--- a/crates/ethernity-detector-mev/Cargo.toml
+++ b/crates/ethernity-detector-mev/Cargo.toml
@@ -17,6 +17,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde = { workspace = true, features = ["derive"] }
 chrono = { workspace = true }
 dashmap = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/ethernity-detector-mev/src/attack_detector.rs
+++ b/crates/ethernity-detector-mev/src/attack_detector.rs
@@ -202,6 +202,19 @@ impl AttackDetector {
         }
         None
     }
+
+    /// Consumes [`ImpactEvent`]s and emits [`ThreatEvent`].
+    pub async fn process_stream(
+        &self,
+        mut rx: tokio::sync::mpsc::Receiver<crate::events::ImpactEvent>,
+        tx: tokio::sync::mpsc::Sender<crate::events::ThreatEvent>,
+    ) {
+        while let Some(ev) = rx.recv().await {
+            if let Some(report) = self.analyze_group(&ev.group) {
+                let _ = tx.send(crate::events::ThreatEvent { report }).await;
+            }
+        }
+    }
 }
 
 

--- a/crates/ethernity-detector-mev/src/events.rs
+++ b/crates/ethernity-detector-mev/src/events.rs
@@ -1,0 +1,49 @@
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+use ethereum_types::Address;
+use ethernity_core::types::TransactionHash;
+use crate::{TxGroup, StateSnapshot, GroupImpact, AttackReport};
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawTx {
+    pub tx_hash: TransactionHash,
+    pub to: Address,
+    pub input: Vec<u8>,
+    pub first_seen: u64,
+    pub gas_price: f64,
+    pub max_priority_fee_per_gas: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotEvent {
+    pub group: TxGroup,
+    pub snapshots: HashMap<Address, StateSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImpactEvent {
+    pub group: TxGroup,
+    pub impact: GroupImpact,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreatEvent {
+    pub report: AttackReport,
+}
+
+/// Simple event bus wrapper over [`tokio::sync::mpsc`] channels.
+pub struct EventBus<T> {
+    sender: mpsc::Sender<T>,
+}
+
+impl<T> EventBus<T> {
+    pub fn new(capacity: usize) -> (Self, mpsc::Receiver<T>) {
+        let (tx, rx) = mpsc::channel(capacity);
+        (Self { sender: tx }, rx)
+    }
+
+    pub fn sender(&self) -> mpsc::Sender<T> {
+        self.sender.clone()
+    }
+}

--- a/crates/ethernity-detector-mev/src/lib.rs
+++ b/crates/ethernity-detector-mev/src/lib.rs
@@ -11,6 +11,7 @@ mod state_impact_evaluator;
 mod state_cache_manager;
 mod attack_detector;
 mod mempool_supervisor;
+mod events;
 
 pub use tx_nature_tagger::*;
 pub use tx_aggregator::*;
@@ -18,3 +19,4 @@ pub use state_impact_evaluator::*;
 pub use state_cache_manager::*;
 pub use attack_detector::*;
 pub use mempool_supervisor::*;
+pub use events::*;

--- a/crates/ethernity-detector-mev/src/tx_aggregator.rs
+++ b/crates/ethernity-detector-mev/src/tx_aggregator.rs
@@ -163,5 +163,20 @@ impl TxAggregator {
             / group.txs.len() as f64;
         var.sqrt() > 0.2
     }
+
+    /// Consumes annotated transactions and emits updated groups.
+    pub async fn process_stream(
+        mut self,
+        mut rx: tokio::sync::mpsc::Receiver<AnnotatedTx>,
+        tx: tokio::sync::mpsc::Sender<TxGroup>,
+    ) {
+        while let Some(txn) = rx.recv().await {
+            if let Some(key) = self.add_tx(txn) {
+                if let Some(g) = self.groups.get(&key) {
+                    let _ = tx.send(g.clone()).await;
+                }
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `events` module for domain message passing
- implement async `process_stream` handlers across detection layers
- derive serialization for new event structures
- expose channels via `EventBus`
- enable `tokio` dependency for runtime support

## Testing
- `cargo check -p ethernity-detector-mev`
- `cargo test -p ethernity-detector-mev`

------
https://chatgpt.com/codex/tasks/task_e_68595e2a01c48332a2ea65f3a90bc3f0