### PR TITLE
Implement MEV detector interfaces

### DIFF
--- a/crates/ethernity-detector-mev/src/lib.rs
+++ b/crates/ethernity-detector-mev/src/lib.rs
@@ -12,6 +12,8 @@ mod state_cache_manager;
 mod attack_detector;
 mod mempool_supervisor;
 mod events;
+mod traits;
+mod rpc_state_provider;
 
 pub use tx_nature_tagger::*;
 pub use tx_aggregator::*;
@@ -20,3 +22,5 @@ pub use state_cache_manager::*;
 pub use attack_detector::*;
 pub use mempool_supervisor::*;
 pub use events::*;
+pub use traits::*;
+pub use rpc_state_provider::*;

--- a/crates/ethernity-detector-mev/src/rpc_state_provider.rs
+++ b/crates/ethernity-detector-mev/src/rpc_state_provider.rs
@@ -1,0 +1,102 @@
+use async_trait::async_trait;
+use ethernity_core::{error::{Error, Result}, traits::RpcProvider};
+use ethereum_types::{Address, U256};
+use lru::LruCache;
+use parking_lot::Mutex;
+use std::num::NonZeroUsize;
+
+use crate::traits::StateProvider;
+
+/// Implementação padrão de [`StateProvider`] usando [`RpcProvider`].
+pub struct RpcStateProvider<P> {
+    primary: P,
+    fallback: Option<P>,
+    reserves_cache: Mutex<LruCache<Address, (U256, U256)>>,
+    slot0_cache: Mutex<LruCache<Address, (U256, U256)>>,
+}
+
+impl<P: RpcProvider + Clone> RpcStateProvider<P> {
+    /// Cria um novo provedor apenas com instancia primária.
+    pub fn new(primary: P) -> Self {
+        Self {
+            primary,
+            fallback: None,
+            reserves_cache: Mutex::new(LruCache::new(NonZeroUsize::new(128).unwrap())),
+            slot0_cache: Mutex::new(LruCache::new(NonZeroUsize::new(128).unwrap())),
+        }
+    }
+
+    /// Define provedor de fallback.
+    pub fn with_fallback(primary: P, fallback: P) -> Self {
+        Self {
+            primary,
+            fallback: Some(fallback),
+            reserves_cache: Mutex::new(LruCache::new(NonZeroUsize::new(128).unwrap())),
+            slot0_cache: Mutex::new(LruCache::new(NonZeroUsize::new(128).unwrap())),
+        }
+    }
+
+    async fn call_inner(&self, provider: &P, to: Address, data: &[u8]) -> Result<Vec<u8>> {
+        provider.call(to, data.to_vec()).await
+    }
+}
+
+#[async_trait]
+impl<P> StateProvider for RpcStateProvider<P>
+where
+    P: RpcProvider + Clone + Send + Sync,
+{
+    async fn reserves(&self, address: Address) -> Result<(U256, U256)> {
+        if let Some(v) = self.reserves_cache.lock().get(&address).cloned() {
+            return Ok(v);
+        }
+        let data = vec![0x09, 0x02, 0xf1, 0xac];
+        let out = match self.call_inner(&self.primary, address, &data).await {
+            Ok(v) => v,
+            Err(e) => {
+                if let Some(ref fb) = self.fallback {
+                    fb.call(address, data.clone()).await?
+                } else {
+                    return Err(e);
+                }
+            }
+        };
+        if out.len() < 64 {
+            return Err(Error::DecodeError("invalid getReserves response".into()));
+        }
+        let v0 = U256::from_big_endian(&out[0..32]);
+        let v1 = U256::from_big_endian(&out[32..64]);
+        let tuple = (v0, v1);
+        self.reserves_cache.lock().put(address, tuple.clone());
+        Ok(tuple)
+    }
+
+    async fn slot0(&self, address: Address) -> Result<(U256, U256)> {
+        if let Some(v) = self.slot0_cache.lock().get(&address).cloned() {
+            return Ok(v);
+        }
+        let data = vec![0x38, 0x50, 0xc7, 0xbd]; // selector slot0()
+        let out = match self.call_inner(&self.primary, address, &data).await {
+            Ok(v) => v,
+            Err(e) => {
+                if let Some(ref fb) = self.fallback {
+                    fb.call(address, data.clone()).await?
+                } else {
+                    return Err(e);
+                }
+            }
+        };
+        if out.len() < 32 {
+            return Err(Error::DecodeError("invalid slot0 response".into()));
+        }
+        let v0 = U256::from_big_endian(&out[0..32]);
+        let v1 = if out.len() >= 64 {
+            U256::from_big_endian(&out[32..64])
+        } else {
+            U256::zero()
+        };
+        let tuple = (v0, v1);
+        self.slot0_cache.lock().put(address, tuple.clone());
+        Ok(tuple)
+    }
+}

--- a/crates/ethernity-detector-mev/src/traits.rs
+++ b/crates/ethernity-detector-mev/src/traits.rs
@@ -1,0 +1,41 @@
+use async_trait::async_trait;
+use ethernity_core::{error::Result, types::TransactionHash};
+use ethereum_types::{Address, U256};
+
+/// Interface para obtenção de estado de contratos.
+#[async_trait]
+pub trait StateProvider: Send + Sync {
+    /// Retorna as reserves (token0, token1) de um par.
+    async fn reserves(&self, address: Address) -> Result<(U256, U256)>;
+
+    /// Retorna informações do slot0 (sqrtPriceX96, liquidez).
+    async fn slot0(&self, address: Address) -> Result<(U256, U256)>;
+}
+
+/// Predição de tag da transação.
+#[derive(Debug, Clone)]
+pub struct TagPrediction {
+    pub tag: String,
+    pub confidence: f64,
+}
+
+/// Classificador de transações com pontuação probabilística.
+#[async_trait]
+pub trait TransactionClassifier: Send + Sync {
+    async fn classify(
+        &self,
+        to: Address,
+        input: &[u8],
+        tx_hash: TransactionHash,
+    ) -> Result<Vec<TagPrediction>>;
+}
+
+/// Modelo de impacto econômico.
+pub trait ImpactModel: Send + Sync {
+    fn evaluate_group(
+        &self,
+        group: &crate::TxGroup,
+        victims: &[crate::VictimInput],
+        snapshot: &crate::StateSnapshot,
+    ) -> crate::GroupImpact;
+}


### PR DESCRIPTION
## Summary
- define new traits (`StateProvider`, `TransactionClassifier`, `ImpactModel`)
- implement `TransactionClassifier` for `TxNatureTagger`
- add `RpcStateProvider` with cache and fallback
- parameterize `StateImpactEvaluator` with `ImpactModelParams`

## Testing
- `cargo test -p ethernity-detector-mev`
- `cargo test --workspace -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685960a98de48332ae0ca676a68a0d37