### PR TITLE
Refactor attack detection verdict

### DIFF
--- a/crates/ethernity-detector-mev/src/events.rs
+++ b/crates/ethernity-detector-mev/src/events.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use ethereum_types::Address;
 use ethernity_core::types::TransactionHash;
-use crate::{TxGroup, StateSnapshot, GroupImpact, AttackReport};
+use crate::{TxGroup, StateSnapshot, GroupImpact, AttackVerdict};
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,7 +29,7 @@ pub struct ImpactEvent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreatEvent {
-    pub report: AttackReport,
+    pub verdict: AttackVerdict,
 }
 
 /// Simple event bus wrapper over [`tokio::sync::mpsc`] channels.

--- a/crates/ethernity-detector-mev/tests/attack_detector_basic.rs
+++ b/crates/ethernity-detector-mev/tests/attack_detector_basic.rs
@@ -1,4 +1,4 @@
-use ethernity_detector_mev::{AnnotatedTx, TxAggregator, AttackDetector, DetectedAttackType};
+use ethernity_detector_mev::{AnnotatedTx, TxAggregator, AttackDetector, AttackType};
 use ethereum_types::{Address, H256};
 
 #[test]
@@ -26,7 +26,10 @@ fn detect_basic_frontrun() {
     let group = aggr.groups().values().next().unwrap();
     let detector = AttackDetector::new(1.0, 10);
     let res = detector.analyze_group(group).expect("should detect");
-    assert_eq!(res.attack_type, Some(DetectedAttackType::Frontrun));
+    match res.attack_type {
+        Some(AttackType::Frontrun { .. }) => {}
+        _ => panic!("expected frontrun"),
+    }
 }
 
 #[test]
@@ -56,7 +59,10 @@ fn detect_basic_sandwich() {
     let group = aggr.groups().values().next().unwrap();
     let detector = AttackDetector::new(1.0, 10);
     let res = detector.analyze_group(group).expect("should detect");
-    assert_eq!(res.attack_type, Some(DetectedAttackType::Sandwich));
+    match res.attack_type {
+        Some(AttackType::Sandwich { .. }) => {}
+        _ => panic!("expected sandwich"),
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- add `AttackType` with justification text
- introduce `AttackVerdict` with confidence and reconsiderable fields
- update `AttackDetector` to emit `AttackVerdict`
- adjust `ThreatEvent` and tests for new structures

## Testing
- `cargo test -- --list` *(fails: could not complete build)*

------
https://chatgpt.com/codex/tasks/task_e_68598092716883329033f95abb10335f