### PR TITLE
Async FSM supervisor

### DIFF
--- a/crates/ethernity-detector-mev/README.md
+++ b/crates/ethernity-detector-mev/README.md
@@ -92,6 +92,16 @@ Orquestra todo o ciclo:
 - Regula ingestão de transações
 - Controla janelas de agrupamento
 - Sincroniza blocos com `blockNumber`
+- Atua como **FSM assíncrona** guiada por eventos `SupervisorEvent`
+
+```rust
+enum SupervisorEvent {
+    NewTxObserved(Tx),
+    BlockAdvanced(BlockMetadata),
+    StateRefreshed(String),
+    GroupFinalized(String),
+}
+```
 
   → Garante consistência temporal e coordenação entre os módulos.
 

--- a/crates/ethernity-detector-mev/src/events.rs
+++ b/crates/ethernity-detector-mev/src/events.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use ethereum_types::Address;
 use ethernity_core::types::TransactionHash;
-use crate::{TxGroup, StateSnapshot, GroupImpact, AttackVerdict};
+use crate::{AnnotatedTx, TxGroup, StateSnapshot, GroupImpact, AttackVerdict};
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,6 +30,19 @@ pub struct ImpactEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreatEvent {
     pub verdict: AttackVerdict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockMetadata {
+    pub number: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SupervisorEvent {
+    NewTxObserved(AnnotatedTx),
+    BlockAdvanced(BlockMetadata),
+    StateRefreshed(String),
+    GroupFinalized(String),
 }
 
 /// Simple event bus wrapper over [`tokio::sync::mpsc`] channels.


### PR DESCRIPTION
## Summary
- add `SupervisorEvent` and `BlockMetadata` event types
- refactor `MempoolSupervisor` into async FSM with `process_stream`
- document the new event driven design

## Testing
- `cargo test -p ethernity-detector-mev` *(fails: build takes too long)*

------
https://chatgpt.com/codex/tasks/task_e_68598dd231408332babaa4929af78a86