### PR TITLE
Add concurrency test for TxAggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "ethernity-core",
  "ethers",
  "hex",
+ "loom",
  "lru 0.10.1",
  "parking_lot",
  "redb",
@@ -1605,6 +1606,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -2241,7 +2256,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -2255,7 +2270,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -2309,6 +2324,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,6 +2352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2946,7 +2983,7 @@ dependencies = [
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "unarray",
 ]
 
@@ -3137,8 +3174,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3149,8 +3195,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3407,6 +3459,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4257,10 +4315,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -4651,6 +4713,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4661,6 +4745,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4690,6 +4785,16 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4790,6 +4895,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/ethernity-detector-mev/Cargo.toml
+++ b/crates/ethernity-detector-mev/Cargo.toml
@@ -25,3 +25,4 @@ serde_json = { workspace = true }
 hex = "0.4"
 tokio = { workspace = true, features = ["full"] }
 tempfile = "3"
+loom = "0.7"

--- a/crates/ethernity-detector-mev/tests/concurrency_aggregator.rs
+++ b/crates/ethernity-detector-mev/tests/concurrency_aggregator.rs
@@ -1,0 +1,65 @@
+#[cfg(loom)]
+use loom::sync::{Arc, Mutex};
+#[cfg(loom)]
+use loom::thread;
+#[cfg(not(loom))]
+use std::sync::{Arc, Mutex};
+#[cfg(not(loom))]
+use std::thread;
+
+use ethernity_detector_mev::{AnnotatedTx, TxAggregator};
+use ethereum_types::{Address, H256};
+
+fn sample_tx(idx: u8) -> AnnotatedTx {
+    AnnotatedTx {
+        tx_hash: H256::repeat_byte(idx),
+        token_paths: vec![Address::repeat_byte(0x01), Address::repeat_byte(0x02)],
+        targets: vec![Address::repeat_byte(0xaa)],
+        tags: vec!["swap-v2".to_string()],
+        first_seen: idx as u64,
+        gas_price: 1.0,
+        max_priority_fee_per_gas: None,
+        confidence: 1.0,
+    }
+}
+
+#[test]
+fn concurrent_add_finalize() {
+    #[cfg(loom)]
+    {
+        let mut builder = loom::model::Builder::new();
+        builder.max_threads = 10;
+        builder.check(|| {
+            run_test(10, 2);
+        });
+    }
+    #[cfg(not(loom))]
+    {
+        run_test(100, 20);
+    }
+}
+
+fn run_test(add_threads: usize, finalize_threads: usize) {
+    let aggr = Arc::new(Mutex::new(TxAggregator::new()));
+    let mut handles = Vec::new();
+    for i in 0..add_threads as u8 {
+        let a = Arc::clone(&aggr);
+        handles.push(thread::spawn(move || {
+            let tx = sample_tx(i);
+            let mut g = a.lock().unwrap();
+            g.add_tx(tx);
+        }));
+    }
+    for _ in 0..finalize_threads {
+        let a = Arc::clone(&aggr);
+        handles.push(thread::spawn(move || {
+            let mut g = a.lock().unwrap();
+            g.finalize_events(true);
+        }));
+    }
+    for h in handles { h.join().unwrap(); }
+    let g = aggr.lock().unwrap();
+    assert_eq!(g.groups().len(), 1);
+    let group = g.groups().values().next().unwrap();
+    assert_eq!(group.txs.len(), add_threads);
+}


### PR DESCRIPTION
## Summary
- add loom-based concurrency test for transaction aggregation
- include loom as a dev dependency

## Testing
- `cargo test -p ethernity-detector-mev --test concurrency_aggregator -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685ad7a7a8b48332a5acc7ca2f487e77