### PR TITLE
Add extreme liquidity tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ ai_fixer_errors.log
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+snapshot_db_*
+crates/ethernity-detector-mev/test_db

--- a/crates/ethernity-detector-mev/src/state_impact_evaluator.rs
+++ b/crates/ethernity-detector-mev/src/state_impact_evaluator.rs
@@ -239,12 +239,27 @@ impl StateImpactEvaluator {
     }
 
     fn expected_out_v2(amount_in: f64, reserve_in: f64, reserve_out: f64) -> f64 {
-        (amount_in * 997.0 * reserve_out) / (reserve_in * 1000.0 + amount_in * 997.0)
+        if reserve_in <= 0.0 || reserve_out <= 0.0 {
+            return 0.0;
+        }
+        let denom = reserve_in * 1000.0 + amount_in * 997.0;
+        if denom <= 0.0 {
+            return 0.0;
+        }
+        let out = (amount_in * 997.0 * reserve_out) / denom;
+        if out.is_finite() { out } else { 0.0 }
     }
 
     fn expected_out_v3(amount_in: f64, sqrt_price_x96: f64) -> f64 {
+        if sqrt_price_x96 <= 0.0 {
+            return 0.0;
+        }
         let ratio = (sqrt_price_x96 * sqrt_price_x96) / 2_f64.powi(192);
-        amount_in * ratio
+        if !ratio.is_finite() || ratio <= 0.0 {
+            0.0
+        } else {
+            amount_in * ratio
+        }
     }
 
     /// Evaluates groups from [`SnapshotEvent`] and emits [`ImpactEvent`].

--- a/crates/ethernity-detector-mev/tests/extreme_liquidity_math.rs
+++ b/crates/ethernity-detector-mev/tests/extreme_liquidity_math.rs
@@ -1,0 +1,107 @@
+use ethernity_detector_mev::{
+    AnnotatedTx, TxAggregator, VictimInput, StateSnapshot,
+    StateImpactEvaluator, ConstantProductCurve, UniswapV3Curve, ImpactModel,
+    ImpactModelParams,
+};
+use ethereum_types::{Address, H256};
+use std::sync::Arc;
+
+fn make_group(tag: &str) -> (TxAggregator, H256) {
+    let mut aggr = TxAggregator::new();
+    let tx = AnnotatedTx {
+        tx_hash: H256::repeat_byte(0x10),
+        token_paths: vec![Address::repeat_byte(0x01), Address::repeat_byte(0x02)],
+        targets: vec![Address::repeat_byte(0xaa)],
+        tags: vec![tag.to_string()],
+        first_seen: 1,
+        gas_price: 10.0,
+        max_priority_fee_per_gas: None,
+        confidence: 1.0,
+    };
+    let key = aggr.add_tx(tx).unwrap();
+    (aggr, key)
+}
+
+#[test]
+fn constant_product_low_liquidity() {
+    let (aggr, key) = make_group("swap-v2");
+    let group = aggr.groups().get(&key).unwrap();
+    let victims = vec![VictimInput {
+        tx_hash: H256::zero(),
+        amount_in: 1.0,
+        amount_out_min: 0.0,
+        token_behavior_unknown: false,
+    }];
+    let snapshot = StateSnapshot {
+        reserve_in: 1e-18,
+        reserve_out: 1e-18,
+        sqrt_price_x96: None,
+        liquidity: None,
+        state_lag_blocks: 0,
+        reorg_risk_level: "low".into(),
+        volatility_flag: false,
+    };
+    let mut params = ImpactModelParams::default();
+    params.curve_model = Arc::new(ConstantProductCurve);
+    let mut ev = StateImpactEvaluator::new(params);
+    let res = ImpactModel::evaluate_group(&mut ev, group, &victims, &snapshot);
+    let out = res.victims[0].expected_amount_out;
+    assert!(out.is_finite());
+    assert!(out >= 0.0);
+}
+
+#[test]
+fn constant_product_high_liquidity() {
+    let (aggr, key) = make_group("swap-v2");
+    let group = aggr.groups().get(&key).unwrap();
+    let victims = vec![VictimInput {
+        tx_hash: H256::zero(),
+        amount_in: 1e6,
+        amount_out_min: 0.0,
+        token_behavior_unknown: false,
+    }];
+    let snapshot = StateSnapshot {
+        reserve_in: 1e30,
+        reserve_out: 1e30,
+        sqrt_price_x96: None,
+        liquidity: None,
+        state_lag_blocks: 0,
+        reorg_risk_level: "low".into(),
+        volatility_flag: false,
+    };
+    let mut params = ImpactModelParams::default();
+    params.curve_model = Arc::new(ConstantProductCurve);
+    let mut ev = StateImpactEvaluator::new(params);
+    let res = ImpactModel::evaluate_group(&mut ev, group, &victims, &snapshot);
+    let out = res.victims[0].expected_amount_out;
+    assert!(out.is_finite());
+    assert!(out >= 0.0);
+}
+
+#[test]
+fn uniswap_v3_extreme_price() {
+    let (aggr, key) = make_group("swap-v3");
+    let group = aggr.groups().get(&key).unwrap();
+    let victims = vec![VictimInput {
+        tx_hash: H256::zero(),
+        amount_in: 10.0,
+        amount_out_min: 0.0,
+        token_behavior_unknown: false,
+    }];
+    let snapshot = StateSnapshot {
+        reserve_in: 0.0,
+        reserve_out: 0.0,
+        sqrt_price_x96: Some(1e15),
+        liquidity: None,
+        state_lag_blocks: 0,
+        reorg_risk_level: "low".into(),
+        volatility_flag: false,
+    };
+    let mut params = ImpactModelParams::default();
+    params.curve_model = Arc::new(UniswapV3Curve);
+    let mut ev = StateImpactEvaluator::new(params);
+    let res = ImpactModel::evaluate_group(&mut ev, group, &victims, &snapshot);
+    let out = res.victims[0].expected_amount_out;
+    assert!(out.is_finite());
+    assert!(out >= 0.0);
+}


### PR DESCRIPTION
## Summary
- handle extreme pool values in StateImpactEvaluator
- ensure snapshot DB artifacts are ignored
- test extreme liquidity maths

## Testing
- `cargo test --quiet --test extreme_liquidity_math`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ad7d910e883328a6a4548493fb731