### PR TITLE
Add concurrency test for snapshot repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,7 @@ dependencies = [
  "ethereum-types",
  "ethernity-core",
  "ethers",
+ "futures",
  "hex",
  "loom",
  "lru 0.10.1",

--- a/crates/ethernity-detector-mev/Cargo.toml
+++ b/crates/ethernity-detector-mev/Cargo.toml
@@ -26,3 +26,4 @@ hex = "0.4"
 tokio = { workspace = true, features = ["full"] }
 tempfile = "3"
 loom = "0.7"
+futures = { workspace = true }


### PR DESCRIPTION
## Summary
- add `futures` as dev-dependency for detector
- add multi-threaded deadlock prevention test for `StateSnapshotRepository`

## Testing
- `cargo test -p ethernity-detector-mev concurrent_snapshot_deadlock_prevention -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685adcc4e49c8332bc1115712d325488