### PR TITLE
Add hybrid attack detection support

### DIFF
--- a/crates/ethernity-detector-mev/tests/attack_detector_basic.rs
+++ b/crates/ethernity-detector-mev/tests/attack_detector_basic.rs
@@ -26,10 +26,7 @@ fn detect_basic_frontrun() {
     let group = aggr.groups().values().next().unwrap();
     let detector = AttackDetector::new(1.0, 10);
     let res = detector.analyze_group(group).expect("should detect");
-    match res.attack_type {
-        Some(AttackType::Frontrun { .. }) => {}
-        _ => panic!("expected frontrun"),
-    }
+    assert!(res.attack_types.iter().any(|a| matches!(a, AttackType::Frontrun { .. })));
 }
 
 #[test]
@@ -59,10 +56,7 @@ fn detect_basic_sandwich() {
     let group = aggr.groups().values().next().unwrap();
     let detector = AttackDetector::new(1.0, 10);
     let res = detector.analyze_group(group).expect("should detect");
-    match res.attack_type {
-        Some(AttackType::Sandwich { .. }) => {}
-        _ => panic!("expected sandwich"),
-    }
+    assert!(res.attack_types.iter().any(|a| matches!(a, AttackType::Sandwich { .. })));
 }
 
 

--- a/crates/ethernity-detector-mev/tests/complex_mev_scenarios.rs
+++ b/crates/ethernity-detector-mev/tests/complex_mev_scenarios.rs
@@ -60,7 +60,7 @@ fn detect_complex_multi_victim_sandwich() {
     let group = aggr.groups().values().next().unwrap();
     let detector = AttackDetector::new(1.0, 10);
     let verdict = detector.analyze_group(group).expect("should detect attack");
-    assert!(matches!(verdict.attack_type, Some(AttackType::Sandwich { .. })));
+    assert!(verdict.attack_types.iter().any(|a| matches!(a, AttackType::Sandwich { .. })));
 }
 
 #[test]

--- a/crates/ethernity-detector-mev/tests/integration_full_pipeline.rs
+++ b/crates/ethernity-detector-mev/tests/integration_full_pipeline.rs
@@ -139,6 +139,6 @@ async fn integration_full_pipeline() {
         .analyze_group(group)
         .expect("verdict");
     assert_eq!(verdict.group_key, group.group_key);
-    assert!(matches!(verdict.attack_type, Some(_)));
+    assert!(!verdict.attack_types.is_empty());
 }
 


### PR DESCRIPTION
## Summary
- allow `AttackDetector` to detect multiple attack types simultaneously
- compute confidence considering combined attacks
- update existing tests for new verdict structure
- add `hybrid_attack_comprehensive_detection` test covering combined frontrun/sandwich/backrun scenario

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685adcfed2288332a12a3b3622b5513b