### PR TITLE
Add flash loan impact test

### DIFF
--- a/crates/ethernity-detector-mev/tests/complex_mev_scenarios.rs
+++ b/crates/ethernity-detector-mev/tests/complex_mev_scenarios.rs
@@ -85,6 +85,7 @@ fn state_impact_deflationary_multi_victims() {
             amount_in: 100.0,
             amount_out_min: 97.0,
             token_behavior_unknown: true,
+            flash_loan_amount: None,
         })
         .collect();
 

--- a/crates/ethernity-detector-mev/tests/extreme_liquidity_math.rs
+++ b/crates/ethernity-detector-mev/tests/extreme_liquidity_math.rs
@@ -31,6 +31,7 @@ fn constant_product_low_liquidity() {
         amount_in: 1.0,
         amount_out_min: 0.0,
         token_behavior_unknown: false,
+        flash_loan_amount: None,
     }];
     let snapshot = StateSnapshot {
         reserve_in: 1e-18,
@@ -59,6 +60,7 @@ fn constant_product_high_liquidity() {
         amount_in: 1e6,
         amount_out_min: 0.0,
         token_behavior_unknown: false,
+        flash_loan_amount: None,
     }];
     let snapshot = StateSnapshot {
         reserve_in: 1e30,
@@ -87,6 +89,7 @@ fn uniswap_v3_extreme_price() {
         amount_in: 10.0,
         amount_out_min: 0.0,
         token_behavior_unknown: false,
+        flash_loan_amount: None,
     }];
     let snapshot = StateSnapshot {
         reserve_in: 0.0,

--- a/crates/ethernity-detector-mev/tests/impact_basic.rs
+++ b/crates/ethernity-detector-mev/tests/impact_basic.rs
@@ -27,6 +27,7 @@ fn evaluate_basic() {
         amount_in: 100.0,
         amount_out_min: 90.0,
         token_behavior_unknown: false,
+        flash_loan_amount: None,
     }];
 
     let snapshot = StateSnapshot {


### PR DESCRIPTION
## Summary
- handle flash loan trades by adding `flash_loan_amount` in `VictimInput`
- use the flash loan amount when calculating trade impact
- update tests for new field
- add a new `flash_loan_impact_detection` test

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685adce818888332bfd1d482ead7b7d3