### PR TITLE
Add extreme value stability test

### DIFF
--- a/crates/ethernity-detector-mev/tests/extreme_liquidity_math.rs
+++ b/crates/ethernity-detector-mev/tests/extreme_liquidity_math.rs
@@ -105,3 +105,31 @@ fn uniswap_v3_extreme_price() {
     assert!(out.is_finite());
     assert!(out >= 0.0);
 }
+
+#[test]
+fn numerical_stability_extreme_values() {
+    let (aggr, key) = make_group("swap-v2");
+    let group = aggr.groups().get(&key).unwrap();
+    let victims = vec![VictimInput {
+        tx_hash: H256::zero(),
+        amount_in: f64::MAX,
+        amount_out_min: 0.0,
+        token_behavior_unknown: false,
+    }];
+    let snapshot = StateSnapshot {
+        reserve_in: 1e-18,
+        reserve_out: 1e-18,
+        sqrt_price_x96: None,
+        liquidity: None,
+        state_lag_blocks: 0,
+        reorg_risk_level: "low".into(),
+        volatility_flag: false,
+    };
+    let mut params = ImpactModelParams::default();
+    params.curve_model = Arc::new(ConstantProductCurve);
+    let mut ev = StateImpactEvaluator::new(params);
+    let res = ImpactModel::evaluate_group(&mut ev, group, &victims, &snapshot);
+    let out = res.victims[0].expected_amount_out;
+    assert!(out.is_finite());
+    assert!(out >= 0.0);
+}


### PR DESCRIPTION
## Summary
- add `numerical_stability_extreme_values` to test overflow/underflow handling in `StateImpactEvaluator`

## Testing
- `cargo test -p ethernity-detector-mev --test extreme_liquidity_math numerical_stability_extreme_values -- --nocapture`
- `cargo test --workspace --lib --tests --release --locked`

------
https://chatgpt.com/codex/tasks/task_e_685add5c80b88332ad19e3d49dd09446