### PR TITLE
Add LRU limit to TxAggregator

### DIFF
--- a/crates/ethernity-detector-mev/tests/aggregator_extended.rs
+++ b/crates/ethernity-detector-mev/tests/aggregator_extended.rs
@@ -236,3 +236,36 @@ async fn events_process_stream_events() {
     assert!(matches!(events.last().unwrap(), AggregationEvent::FinalizedGroup { complete: true, .. }));
 }
 
+#[test]
+fn group_count_hard_limit_enforcement() {
+    let mut aggr = TxAggregator::new();
+    let target = Address::repeat_byte(0xaa);
+    let tags = vec!["swap-v2".to_string()];
+
+    let mut first_key = H256::zero();
+    let mut last_key = H256::zero();
+    // create 100k unique groups
+    for i in 0..100_000u64 {
+        let tokens = vec![
+            Address::from_low_u64_be(i),
+            Address::from_low_u64_be(i.wrapping_add(1)),
+        ];
+        let tx = make_tx(
+            (i % 255) as u8,
+            i,
+            1.0,
+            0.9,
+            tokens.clone(),
+            vec![target],
+            tags.clone(),
+        );
+        let key = aggr.add_tx(tx).unwrap();
+        if i == 0 { first_key = key; }
+        last_key = key;
+    }
+
+    assert_eq!(aggr.groups().len(), TxAggregator::MAX_GROUPS);
+    assert!(!aggr.groups().contains_key(&first_key));
+    assert!(aggr.groups().contains_key(&last_key));
+}
+


### PR DESCRIPTION
## Summary
- enforce a hard cap on TxAggregator groups via an LRU cache
- add regression test for group count limit and eviction policy

## Testing
- `cargo test --workspace --tests --no-run`
- `cargo test --workspace --tests`

------
https://chatgpt.com/codex/tasks/task_e_685add4c6d9883329e0a0a7625d04703