### PR TITLE
Add concurrency test for mempool supervisor

### DIFF
--- a/crates/ethernity-detector-mev/src/mempool_supervisor.rs
+++ b/crates/ethernity-detector-mev/src/mempool_supervisor.rs
@@ -182,9 +182,11 @@ impl<P: RpcProvider + Clone> MempoolSupervisor<P> {
         if let Some(bn) = new_block {
             result = self.finalize_groups(bn).await?;
             self.window_id += 1;
+            self.aggregator.set_window_start(self.window_id);
         } else if self.aggregator.groups().len() >= self.max_active_groups {
             result = self.finalize_groups(block).await?;
             self.window_id += 1;
+            self.aggregator.set_window_start(self.window_id);
         }
         Ok(result)
     }
@@ -204,6 +206,7 @@ impl<P: RpcProvider + Clone> MempoolSupervisor<P> {
                     let _ = tx.send(g).await;
                 }
                 self.window_id += 1;
+                self.aggregator.set_window_start(self.window_id);
                 self.last_block = number;
             }
             SupervisorEvent::StateRefreshed(_tag) => {}


### PR DESCRIPTION
## Summary
- ensure `TxAggregator` window is updated on every window advance
- add `supervisor_event_ordering_consistency` to stress concurrent event handling

## Testing
- `cargo test -p ethernity-detector-mev --test mempool_supervisor -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685aec5c53ec8332bf644bab0147b412