### PR TITLE
Fix impact state test compile error

### DIFF
--- a/crates/ethernity-detector-mev/src/state_impact_evaluator.rs
+++ b/crates/ethernity-detector-mev/src/state_impact_evaluator.rs
@@ -87,7 +87,7 @@ impl CurveModel for ConstantProductCurve {
             amount_in,
             snapshot.reserve_in,
             snapshot.reserve_out,
-            self.fee_rate,
+            self.fee,
         )
     }
 

--- a/crates/ethernity-detector-mev/tests/impact_state.rs
+++ b/crates/ethernity-detector-mev/tests/impact_state.rs
@@ -311,7 +311,7 @@ fn high_volatility_penalizes_confidence() {
 fn dynamic_fee_impact() {
     let (aggr, key) = make_group(vec!["swap-v2".into()]);
     let group = aggr.groups().get(&key).unwrap();
-    let curve = ConstantProductCurve { fee_rate: 0.005 };
+    let curve = ConstantProductCurve { fee: 0.005 };
     let params = ImpactModelParams { curve_model: Arc::new(curve), ..Default::default() };
     let mut ev = StateImpactEvaluator::new(params);
     let victims = vec![VictimInput { tx_hash: H256::zero(), amount_in: 100.0, amount_out_min: 95.0, token_behavior_unknown: false, flash_loan_amount: None }];


### PR DESCRIPTION
## Summary
- fix constant product curve field in impact evaluator
- update impact state test for new field

## Testing
- `cargo test -p ethernity-detector-mev -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_685b1878ba5883329597bf8e5bfc2736