### PR TITLE
Fix warnings in detector tests

### DIFF
--- a/crates/ethernity-detector-mev/tests/aggregator_extended.rs
+++ b/crates/ethernity-detector-mev/tests/aggregator_extended.rs
@@ -234,7 +234,7 @@ fn events_finalize_events() {
 
 #[tokio::test]
 async fn events_process_stream_events() {
-    let mut aggr = TxAggregator::new();
+    let aggr = TxAggregator::new();
     let tokens = vec![Address::repeat_byte(0x01), Address::repeat_byte(0x02)];
     let targets = vec![Address::repeat_byte(0xaa)];
     let tags = vec!["swap-v2".to_string()];

--- a/crates/ethernity-detector-mev/tests/attack_detector_extended.rs
+++ b/crates/ethernity-detector-mev/tests/attack_detector_extended.rs
@@ -103,7 +103,7 @@ fn edge_multiple_attacks_prefers_sandwich() {
     let targets = vec![Address::repeat_byte(0xaa)];
     let tags = vec!["swap-v2".to_string()];
 
-    let mut a = AnnotatedTx {
+    let a = AnnotatedTx {
         tx_hash: H256::repeat_byte(0x60),
         token_paths: token_paths.clone(),
         targets: targets.clone(),
@@ -146,7 +146,7 @@ fn edge_low_confidence_reconsiderable() {
     // long tags to trigger anomaly
     let tags = vec!["swap-v2".to_string(), "very-very-long-tag-over-twenty".to_string(), "another-very-long-tag".to_string()];
 
-    let mut tx1 = AnnotatedTx {
+    let tx1 = AnnotatedTx {
         tx_hash: H256::repeat_byte(0x70),
         token_paths: token_paths.clone(),
         targets: targets.clone(),
@@ -176,7 +176,7 @@ fn priority_max_fee_respected() {
     let targets = vec![Address::repeat_byte(0xaa)];
     let tags = vec!["swap-v2".to_string()];
 
-    let mut a = AnnotatedTx {
+    let a = AnnotatedTx {
         tx_hash: H256::repeat_byte(0x80),
         token_paths: token_paths.clone(),
         targets: targets.clone(),
@@ -206,7 +206,7 @@ fn priority_ordering_by_seen() {
     let targets = vec![Address::repeat_byte(0xaa)];
     let tags = vec!["swap-v2".to_string()];
 
-    let mut a = AnnotatedTx {
+    let a = AnnotatedTx {
         tx_hash: H256::repeat_byte(0x90),
         token_paths: token_paths.clone(),
         targets: targets.clone(),
@@ -236,7 +236,7 @@ fn hybrid_attack_comprehensive_detection() {
     let tags = vec!["swap-v2".to_string()];
 
     // frontrun attacker
-    let mut a1 = AnnotatedTx {
+    let a1 = AnnotatedTx {
         tx_hash: H256::repeat_byte(0xa0),
         token_paths: token_paths.clone(),
         targets: targets.clone(),

--- a/crates/ethernity-detector-mev/tests/integration_full_pipeline.rs
+++ b/crates/ethernity-detector-mev/tests/integration_full_pipeline.rs
@@ -134,7 +134,7 @@ async fn integration_full_pipeline() {
         .get_state(to, 1, SnapshotProfile::Basic)
         .expect("snapshot present");
 
-    let impact = StateImpactEvaluator::evaluate(group, &[], &snap);
+    let _impact = StateImpactEvaluator::evaluate(group, &[], &snap);
     let verdict = AttackDetector::new(1.0, 10)
         .analyze_group(group)
         .expect("verdict");

--- a/crates/ethernity-detector-mev/tests/state_recovery_chaos.rs
+++ b/crates/ethernity-detector-mev/tests/state_recovery_chaos.rs
@@ -83,7 +83,7 @@ async fn deep_reorg_and_db_corruption() {
     // corrupt entries for blocks 2 and 4
     let db_path = dir.path().join("db.redb");
     let db = Database::open(db_path).unwrap();
-    let mut tx = db.begin_write().unwrap();
+    let tx = db.begin_write().unwrap();
     {
         let mut table = tx.open_table(SNAPSHOT_TABLE).unwrap();
         let k2 = format!("0x{:x}:2:basic", target);

--- a/crates/ethernity-detector-mev/tests/tagger_advanced.rs
+++ b/crates/ethernity-detector-mev/tests/tagger_advanced.rs
@@ -1,4 +1,4 @@
-use ethernity_detector_mev::{TxNatureTagger, RawTx, TransactionClassifier, TagPrediction};
+use ethernity_detector_mev::{TxNatureTagger, RawTx, TransactionClassifier};
 use ethernity_core::{traits::RpcProvider, error::{Result, Error}, types::TransactionHash};
 use ethereum_types::{Address, H256};
 use async_trait::async_trait;


### PR DESCRIPTION
## Summary
- clean up unused imports and mutability in test suite of `ethernity-detector-mev`

## Testing
- `cargo test -p ethernity-detector-mev --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_685b392a8afc833297ad9383f121d773