### PR TITLE
Fix block parsing in MEV example

### DIFF
--- a/crates/ethernity-detector-mev/examples/README.md
+++ b/crates/ethernity-detector-mev/examples/README.md
@@ -2,7 +2,7 @@
 
 Este exemplo demonstra o uso básico da crate para detectar oportunidades MEV em um bloco Ethereum.
 
-Execute:
+Execute o exemplo apontando para um RPC que permita obter os blocos com transações completas:
 
 ```bash
 cargo run --example example -- <RPC_ENDPOINT> [BLOCO]

--- a/crates/ethernity-detector-mev/examples/example.rs
+++ b/crates/ethernity-detector-mev/examples/example.rs
@@ -72,8 +72,8 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Analisando bloco {target_block}...");
 
-    // Recupera o bloco e converte para estrutura do web3
-    let block_bytes = rpc_client.get_block(target_block).await?;
+    // Recupera o bloco com detalhes das transações e converte para estrutura do web3
+    let block_bytes = rpc_client.get_block_with_txs(target_block).await?;
     let block: Block<Transaction> = serde_json::from_slice(&block_bytes)?;
 
     // Instancia componentes principais

--- a/crates/ethernity-rpc/README.md
+++ b/crates/ethernity-rpc/README.md
@@ -219,8 +219,8 @@ if let Some(status) = receipt.get("status").and_then(|s| s.as_str()) {
 #### Operações de Bloco
 
 ```rust
-// Obter informações de bloco
-let block_bytes = client.get_block(12345678).await?;
+// Obter informações de bloco com transações completas
+let block_bytes = client.get_block_with_txs(12345678).await?;
 let block: serde_json::Value = serde_json::from_slice(&block_bytes)?;
 
 // Extrair informações do bloco


### PR DESCRIPTION
## Summary
- add `get_block_with_txs` helper to fetch blocks with full transactions
- use the new API in the MEV detector example
- document the new method in README files
- clarify README instructions for running the example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c54b46b788332a7123468648387e1