### PR TITLE
Fix DB lock in mempool example

### DIFF
--- a/crates/ethernity-detector-mev/examples/mempool_monitor.rs
+++ b/crates/ethernity-detector-mev/examples/mempool_monitor.rs
@@ -134,6 +134,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Avaliadores de impacto e detecção de ataques
     let repo_dir = std::env::temp_dir().join("mev_example_db");
+    if repo_dir.exists() {
+        // Remove banco de dados antigo para evitar erro de lock
+        std::fs::remove_dir_all(&repo_dir)?;
+    }
     let repo = StateSnapshotRepository::open(rpc.clone(), &repo_dir)?;
     let mut impact_eval = StateImpactEvaluator::default();
     let detector = AttackDetector::new(1.0, 10);


### PR DESCRIPTION
## Summary
- remove the temporary database directory `/tmp/mev_example_db` before each run of `mempool_monitor`

## Testing
- `cargo test -p ethernity-detector-mev`

------
https://chatgpt.com/codex/tasks/task_e_685c9cddda448332b8ee70b5f1d830fd