### PR TITLE
Add modular architecture to sandwich-victim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anvil"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e29d3ca6c44fd6bc23219f6441303e329ee44580d3cee160df9c5d205e8fc83"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,6 +3447,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sandwich-victim"
+version = "0.1.0"
+dependencies = [
+ "anvil",
+ "anyhow",
+ "ethereum-types",
+ "ethers",
+ "serde",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/ethernity-finder",
     "crates/ethernity-fingerprint",
     "crates/ethernity-detector-mev",
+    "crates/sandwich-victim",
 ]
 
 [workspace.package]

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sandwich-victim"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+ethereum-types = { workspace = true }
+ethers = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+# Dependência opcional para simulação local
+anvil = { version = "0.3", optional = true }
+
+[features]
+default = []
+anvil = ["dep:anvil"]

--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -1,0 +1,19 @@
+# sandwich-victim
+
+Biblioteca para detectar oportunidades de ataque *sandwich* em transações Ethereum. A análise executa a transação em um fork local da blockchain usando `anvil` e calcula:
+
+- rota dos tokens trocados
+- slippage real comparado com a cotação esperada
+- quantidade mínima de tokens capaz de afetar o preço
+- lucro potencial de uma estratégia de front‑run e back‑run
+- identificação dinâmica do router envolvido
+- reconhecimento de todas as variações de funções de swap V2
+
+A arquitetura segue o princípio de responsabilidade única. Cada módulo possui
+uma função clara:
+`simulation` executa a transação em um fork local, `dex` traz utilidades para
+roteadores e funções de swap, `analysis` coleta métricas on-chain e `types` guarda
+as estruturas de dados. Assim o código fica organizado e fácil de manter.
+
+O código expõe funções assíncronas e pode ser extendido com novos métodos de avaliação.
+

--- a/crates/sandwich-victim/src/analysis/mod.rs
+++ b/crates/sandwich-victim/src/analysis/mod.rs
@@ -1,0 +1,179 @@
+use crate::dex::{identify_router, detect_swap_function, RouterInfo, SwapFunction};
+use crate::simulation::{simulate_transaction, SimulationConfig, SimulationOutcome};
+use crate::types::{AnalysisResult, Metrics, TransactionData};
+use crate::utils::{simulate_sandwich_profit, U256Ext};
+use anyhow::{anyhow, Result};
+use ethers::abi::{AbiParser, Token};
+use ethers::prelude::*;
+use ethers::utils::keccak256;
+use ethereum_types::{Address, U256, H256};
+use std::time::Duration;
+
+pub mod onchain;
+use onchain::{get_pair_address, get_pair_reserves};
+
+
+pub async fn analyze_transaction(rpc_endpoint: String, tx: TransactionData) -> Result<AnalysisResult> {
+    let provider = Provider::<Http>::try_from(rpc_endpoint.clone())?.interval(Duration::from_millis(100));
+    let router: RouterInfo = identify_router(&provider, tx.to).await?;
+
+    let sim_config = SimulationConfig { rpc_endpoint };
+    let SimulationOutcome { tx_hash, logs } = simulate_transaction(&sim_config, &tx).await?;
+
+    let (swap_kind, function) = detect_swap_function(&tx.data)
+        .ok_or_else(|| anyhow!("função swap não reconhecida"))?;
+    let tokens = function.decode_input(&tx.data[4..])?;
+
+    let (amount_in, amount_out, amount_in_max, amount_out_min, path) = match swap_kind {
+        SwapFunction::SwapExactTokensForTokens
+        | SwapFunction::SwapExactTokensForETH
+        | SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens
+        | SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens => {
+            let amount_in = tokens[0].clone().into_uint().unwrap();
+            let amount_out_min = tokens[1].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[2]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (Some(amount_in), None, None, Some(amount_out_min), path)
+        }
+        SwapFunction::SwapTokensForExactTokens | SwapFunction::SwapTokensForExactETH => {
+            let amount_out = tokens[0].clone().into_uint().unwrap();
+            let amount_in_max = tokens[1].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[2]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (None, Some(amount_out), Some(amount_in_max), None, path)
+        }
+        SwapFunction::SwapExactETHForTokens
+        | SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens => {
+            let amount_out_min = tokens[0].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[1]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (Some(tx.value), None, None, Some(amount_out_min), path)
+        }
+        SwapFunction::ETHForExactTokens => {
+            let amount_out = tokens[0].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[1]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (None, Some(amount_out), Some(tx.value), None, path)
+        }
+    };
+
+    let path_tokens: Vec<Token> = path.iter().map(|a| Token::Address(*a)).collect();
+    let (expected_out, expected_in) = if let Some(a_in) = amount_in {
+        let abi = AbiParser::default()
+            .parse_function("getAmountsOut(uint256,address[]) returns (uint256[])")?;
+        let data = abi.encode_input(&[Token::Uint(a_in), Token::Array(path_tokens.clone())])?;
+        let req = ethers::types::TransactionRequest {
+            to: Some(NameOrAddress::Address(tx.to)),
+            data: Some(data.into()),
+            ..Default::default()
+        };
+        let call = provider.call(&req.into(), None).await?;
+        let out_tokens = abi.decode_output(&call.0)?;
+        let out = out_tokens[0].clone().into_array().unwrap().last().unwrap().clone().into_uint().unwrap();
+        (Some(out), None)
+    } else if let Some(a_out) = amount_out {
+        let abi = AbiParser::default()
+            .parse_function("getAmountsIn(uint256,address[]) returns (uint256[])")?;
+        let data = abi.encode_input(&[Token::Uint(a_out), Token::Array(path_tokens.clone())])?;
+        let req = ethers::types::TransactionRequest {
+            to: Some(NameOrAddress::Address(tx.to)),
+            data: Some(data.into()),
+            ..Default::default()
+        };
+        let call = provider.call(&req.into(), None).await?;
+        let in_tokens = abi.decode_output(&call.0)?;
+        let inp = in_tokens[0].clone().into_array().unwrap().first().unwrap().clone().into_uint().unwrap();
+        (None, Some(inp))
+    } else {
+        (None, None)
+    };
+
+    let transfer_sig: H256 =
+        H256::from_slice(keccak256("Transfer(address,address,uint256)").as_slice());
+    let mut actual_out = U256::zero();
+    let mut actual_in = U256::zero();
+    for log in &logs {
+        if log.topics.get(0) == Some(&transfer_sig) && log.topics.len() == 3 {
+            let from_addr = Address::from_slice(&log.topics[1].as_bytes()[12..]);
+            let to_addr = Address::from_slice(&log.topics[2].as_bytes()[12..]);
+            if to_addr == tx.from {
+                actual_out = U256::from_big_endian(&log.data.0);
+            }
+            if from_addr == tx.from {
+                actual_in = U256::from_big_endian(&log.data.0);
+            }
+        }
+    }
+
+    let slippage = if let Some(exp_out) = expected_out {
+        if exp_out > actual_out {
+            (exp_out - actual_out).to_f64_lossy() / exp_out.to_f64_lossy()
+        } else {
+            0.0
+        }
+    } else if let Some(exp_in) = expected_in {
+        if actual_in > exp_in {
+            (actual_in - exp_in).to_f64_lossy() / exp_in.to_f64_lossy()
+        } else {
+            0.0
+        }
+    } else {
+        0.0
+    };
+
+    let pair_address = if let Some(factory) = router.factory {
+        get_pair_address(&provider, factory, path[0], path[1]).await?
+    } else {
+        return Err(anyhow!("router não fornece fábrica"));
+    };
+
+    let (reserve_in, reserve_out) = get_pair_reserves(&provider, pair_address).await?;
+    let min_tokens_to_affect = reserve_in / U256::from(100u64);
+    let input_for_profit = amount_in.unwrap_or(actual_in);
+    let potential_profit = simulate_sandwich_profit(input_for_profit, reserve_in, reserve_out);
+
+    let metrics = Metrics {
+        swap_function: swap_kind,
+        token_route: path.clone(),
+        slippage,
+        min_tokens_to_affect,
+        potential_profit,
+        router_address: router.address,
+        router_name: router.name.clone(),
+    };
+
+    let potential_victim = if let Some(out_min) = amount_out_min {
+        slippage > 0.0 && expected_out.unwrap_or(U256::zero()) >= out_min
+    } else if let Some(in_max) = amount_in_max {
+        slippage > 0.0 && actual_in <= in_max
+    } else {
+        slippage > 0.0
+    };
+
+    Ok(AnalysisResult {
+        potential_victim,
+        economically_viable: potential_profit > U256::zero(),
+        simulated_tx: tx_hash,
+        metrics,
+    })
+}

--- a/crates/sandwich-victim/src/analysis/onchain.rs
+++ b/crates/sandwich-victim/src/analysis/onchain.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use ethereum_types::{Address, U256};
+use ethers::abi::{AbiParser, Token};
+use ethers::prelude::*;
+
+/// Consulta as reservas de um par Uniswap V2-like
+pub async fn get_pair_reserves<P>(provider: &P, pair: Address) -> Result<(U256, U256)>
+where
+    P: Middleware,
+    <P as Middleware>::Error: 'static,
+{
+    let abi = AbiParser::default()
+        .parse_function("getReserves() returns (uint112,uint112,uint32)")?;
+    let tx = ethers::types::TransactionRequest {
+        to: Some(NameOrAddress::Address(pair)),
+        data: Some(abi.encode_input(&[])? .into()),
+        ..Default::default()
+    };
+    let out = provider.call(&tx.into(), None).await?;
+    let tokens = abi.decode_output(&out.0)?;
+    Ok((
+        tokens[0].clone().into_uint().unwrap(),
+        tokens[1].clone().into_uint().unwrap(),
+    ))
+}
+
+/// Obtém o endereço do par para dois tokens via factory
+pub async fn get_pair_address<P>(
+    provider: &P,
+    factory: Address,
+    token_a: Address,
+    token_b: Address,
+) -> Result<Address>
+where
+    P: Middleware,
+    <P as Middleware>::Error: 'static,
+{
+    let abi = AbiParser::default()
+        .parse_function("getPair(address,address) view returns (address)")?;
+    let data = abi.encode_input(&[Token::Address(token_a), Token::Address(token_b)])?;
+    let req = ethers::types::TransactionRequest {
+        to: Some(NameOrAddress::Address(factory)),
+        data: Some(data.into()),
+        ..Default::default()
+    };
+    let out = provider.call(&req.into(), None).await?;
+    let tokens = abi.decode_output(&out.0)?;
+    Ok(tokens[0].clone().into_address().unwrap())
+}

--- a/crates/sandwich-victim/src/dex/mod.rs
+++ b/crates/sandwich-victim/src/dex/mod.rs
@@ -1,0 +1,5 @@
+pub mod router;
+pub mod swap;
+
+pub use router::{identify_router, RouterInfo};
+pub use swap::{detect_swap_function, SwapFunction};

--- a/crates/sandwich-victim/src/dex/router.rs
+++ b/crates/sandwich-victim/src/dex/router.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use ethereum_types::{Address, U256};
+use ethers::abi::{AbiParser, Token};
+use ethers::prelude::*;
+
+/// Informações sobre o router detectado
+#[derive(Debug, Clone)]
+pub struct RouterInfo {
+    pub address: Address,
+    pub name: Option<String>,
+    pub factory: Option<Address>,
+}
+
+/// Identifica dinamicamente o router utilizado na transação
+pub async fn identify_router<P>(provider: &P, addr: Address) -> Result<RouterInfo>
+where
+    P: Middleware,
+    <P as Middleware>::Error: 'static,
+{
+    const UNISWAP_V2_BYTES: [u8; 20] = [
+        0x7a, 0x25, 0x0d, 0x56, 0x30, 0xb4, 0xcf, 0x53,
+        0x97, 0x39, 0xdf, 0x2c, 0x5d, 0xac, 0xb4, 0xc6,
+        0x59, 0xf2, 0x48, 0x8d,
+    ];
+    const SUSHI_V2_BYTES: [u8; 20] = [
+        0xd9, 0xe1, 0xce, 0x17, 0xf2, 0x64, 0x1f, 0x24,
+        0xae, 0x83, 0x63, 0x7a, 0xb6, 0x6a, 0x2c, 0xca,
+        0x9c, 0x37, 0x8b, 0x9f,
+    ];
+
+    let name = if addr == Address::from(UNISWAP_V2_BYTES) {
+        Some("UniswapV2".to_string())
+    } else if addr == Address::from(SUSHI_V2_BYTES) {
+        Some("SushiSwap".to_string())
+    } else {
+        None
+    };
+
+    // tenta obter a factory para confirmar ser um router
+    let factory_abi = AbiParser::default()
+        .parse_function("factory() view returns (address)")?;
+    let req = ethers::types::TransactionRequest {
+        to: Some(NameOrAddress::Address(addr)),
+        data: Some(factory_abi.encode_input(&[])? .into()),
+        ..Default::default()
+    };
+    let call_res = provider.call(&req.into(), None).await;
+    let factory = match call_res {
+        Ok(out) => {
+            let tokens = factory_abi.decode_output(&out.0)?;
+            Some(tokens[0].clone().into_address().unwrap())
+        }
+        Err(_) => None,
+    };
+
+    // verifica se responde a getAmountsOut
+    let amounts_out_abi = AbiParser::default()
+        .parse_function("getAmountsOut(uint256,address[])")?;
+    let test_data = amounts_out_abi.encode_input(&[
+        Token::Uint(U256::one()),
+        Token::Array(vec![Token::Address(addr), Token::Address(addr)]),
+    ])?;
+    let req = ethers::types::TransactionRequest {
+        to: Some(NameOrAddress::Address(addr)),
+        data: Some(test_data.into()),
+        ..Default::default()
+    };
+    let _ = provider.call(&req.into(), None).await.ok();
+
+    Ok(RouterInfo {
+        address: addr,
+        name,
+        factory,
+    })
+}

--- a/crates/sandwich-victim/src/dex/swap.rs
+++ b/crates/sandwich-victim/src/dex/swap.rs
@@ -1,0 +1,76 @@
+use ethers::abi::{AbiParser, Function};
+use serde::{Deserialize, Serialize};
+
+/// Funções de swap suportadas em routers compatíveis com Uniswap V2
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SwapFunction {
+    SwapExactTokensForTokens,
+    SwapTokensForExactTokens,
+    SwapExactETHForTokens,
+    SwapTokensForExactETH,
+    SwapExactTokensForETH,
+    ETHForExactTokens,
+    SwapExactTokensForTokensSupportingFeeOnTransferTokens,
+    SwapExactETHForTokensSupportingFeeOnTransferTokens,
+    SwapExactTokensForETHSupportingFeeOnTransferTokens,
+}
+
+impl SwapFunction {
+    fn signature(&self) -> &'static str {
+        match self {
+            SwapFunction::SwapExactTokensForTokens => {
+                "swapExactTokensForTokens(uint256,uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapTokensForExactTokens => {
+                "swapTokensForExactTokens(uint256,uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapExactETHForTokens => {
+                "swapExactETHForTokens(uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapTokensForExactETH => {
+                "swapTokensForExactETH(uint256,uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapExactTokensForETH => {
+                "swapExactTokensForETH(uint256,uint256,address[],address,uint256)"
+            }
+            SwapFunction::ETHForExactTokens => {
+                "swapETHForExactTokens(uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens => {
+                "swapExactTokensForTokensSupportingFeeOnTransferTokens(uint256,uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens => {
+                "swapExactETHForTokensSupportingFeeOnTransferTokens(uint256,address[],address,uint256)"
+            }
+            SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens => {
+                "swapExactTokensForETHSupportingFeeOnTransferTokens(uint256,uint256,address[],address,uint256)"
+            }
+        }
+    }
+}
+
+/// Identifica qual função de swap foi invocada
+pub fn detect_swap_function(data: &[u8]) -> Option<(SwapFunction, Function)> {
+    if data.len() < 4 {
+        return None;
+    }
+    let selector = &data[..4];
+    let mut parser = AbiParser::default();
+    for func in [
+        SwapFunction::SwapExactTokensForTokens,
+        SwapFunction::SwapTokensForExactTokens,
+        SwapFunction::SwapExactETHForTokens,
+        SwapFunction::SwapTokensForExactETH,
+        SwapFunction::SwapExactTokensForETH,
+        SwapFunction::ETHForExactTokens,
+        SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens,
+        SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens,
+        SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens,
+    ] {
+        let f = parser.parse_function(func.signature()).expect("abi parse");
+        if selector == f.short_signature() {
+            return Some((func, f));
+        }
+    }
+    None
+}

--- a/crates/sandwich-victim/src/lib.rs
+++ b/crates/sandwich-victim/src/lib.rs
@@ -1,0 +1,11 @@
+/*! Sandwich Victim
+ *
+ * Crate para detectar oportunidades de ataque do tipo sandwich em transações
+ * Ethereum. Utiliza simulação local para estimar métricas de viabilidade.
+ */
+
+pub mod types;
+pub mod simulation;
+pub mod analysis;
+pub mod dex;
+pub mod utils;

--- a/crates/sandwich-victim/src/simulation.rs
+++ b/crates/sandwich-victim/src/simulation.rs
@@ -1,0 +1,61 @@
+use crate::types::{TransactionData};
+use anyhow::{Result, anyhow};
+use ethers::prelude::*;
+#[cfg(feature = "anvil")]
+use std::time::Duration;
+
+/// Configurações para a simulação local
+#[derive(Debug, Clone)]
+pub struct SimulationConfig {
+    pub rpc_endpoint: String,
+}
+
+/// Resultado simples da simulação
+#[derive(Debug, Clone)]
+pub struct SimulationOutcome {
+    pub tx_hash: Option<H256>,
+    pub logs: Vec<Log>,
+}
+
+/// Executa a transação em um fork local utilizando o Anvil
+pub async fn simulate_transaction(
+    config: &SimulationConfig,
+    tx: &TransactionData,
+) -> Result<SimulationOutcome> {
+    #[cfg(feature = "anvil")]
+    {
+        use anvil::Anvil;
+
+        let anvil = Anvil::new()
+            .fork(config.rpc_endpoint.clone())
+            .spawn();
+
+        let provider = Provider::<Http>::try_from(anvil.endpoint())?.interval(Duration::from_millis(1));
+        let wallet: LocalWallet = anvil.keys()[0].clone().into();
+        let client = SignerMiddleware::new(provider, wallet);
+        let pending = client
+            .send_transaction(
+                TransactionRequest::new()
+                    .from(tx.from)
+                    .to(tx.to)
+                    .data(tx.data.clone())
+                    .value(tx.value)
+                    .gas(tx.gas)
+                    .gas_price(tx.gas_price)
+                    .nonce(tx.nonce),
+                None,
+            )
+            .await?;
+        let receipt = pending.await?;
+        Ok(SimulationOutcome {
+            tx_hash: Some(receipt.transaction_hash),
+            logs: receipt.logs,
+        })
+    }
+    #[cfg(not(feature = "anvil"))]
+    {
+        let _ = config;
+        let _ = tx;
+        Err(anyhow!("anvil feature not enabled"))
+    }
+}

--- a/crates/sandwich-victim/src/types.rs
+++ b/crates/sandwich-victim/src/types.rs
@@ -1,0 +1,36 @@
+use ethereum_types::{Address, U256, H256};
+use crate::dex::SwapFunction;
+use serde::{Deserialize, Serialize};
+
+/// Dados básicos de uma transação Ethereum
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionData {
+    pub from: Address,
+    pub to: Address,
+    pub data: Vec<u8>,
+    pub value: U256,
+    pub gas: u64,
+    pub gas_price: U256,
+    pub nonce: U256,
+}
+
+/// Métricas extraídas durante a simulação
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Metrics {
+    pub swap_function: SwapFunction,
+    pub token_route: Vec<Address>,
+    pub slippage: f64,
+    pub min_tokens_to_affect: U256,
+    pub potential_profit: U256,
+    pub router_address: Address,
+    pub router_name: Option<String>,
+}
+
+/// Resultado final da análise
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnalysisResult {
+    pub potential_victim: bool,
+    pub metrics: Metrics,
+    pub economically_viable: bool,
+    pub simulated_tx: Option<H256>,
+}

--- a/crates/sandwich-victim/src/utils.rs
+++ b/crates/sandwich-victim/src/utils.rs
@@ -1,0 +1,39 @@
+use ethereum_types::U256;
+
+pub trait U256Ext {
+    fn to_f64_lossy(&self) -> f64;
+}
+
+impl U256Ext for U256 {
+    fn to_f64_lossy(&self) -> f64 {
+        let mut bytes = [0u8; 32];
+        self.to_big_endian(&mut bytes);
+        let mut result = 0f64;
+        for &b in &bytes {
+            result = result * 256f64 + b as f64;
+        }
+        result
+    }
+}
+
+pub fn constant_product_output(amount_in: U256, reserve_in: U256, reserve_out: U256) -> U256 {
+    if amount_in.is_zero() {
+        return U256::zero();
+    }
+    let numerator = amount_in * reserve_out;
+    numerator / (reserve_in + amount_in)
+}
+
+pub fn simulate_sandwich_profit(amount_in: U256, reserve_in: U256, reserve_out: U256) -> U256 {
+    let front = amount_in / U256::from(10u64);
+    let out_front = constant_product_output(front, reserve_in, reserve_out);
+    let res_in_after_front = reserve_in + front;
+    let res_out_after_front = reserve_out - out_front;
+    let _victim_out = constant_product_output(amount_in, res_in_after_front, res_out_after_front);
+    let res_in_after_victim = res_in_after_front + amount_in;
+    let res_out_after_victim = res_out_after_front - _victim_out;
+    let back_out = constant_product_output(out_front, res_out_after_victim, res_in_after_victim);
+    if back_out > front { back_out - front } else { U256::zero() }
+}
+
+


### PR DESCRIPTION
## Summary
- refactor sandwich-victim crate to use a clear SRP-based module layout
- move helper on-chain queries into a dedicated module
- split DEX utilities into router and swap modules
- update lib exports and README accordingly

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685f32b84ba88332b35fd408bc826869