### PR TITLE
Add tx hash option to CLI example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "ethereum-types",
  "ethers",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,6 @@ dependencies = [
  "ethereum-types",
  "ethers",
  "serde",
- "serde_json",
  "tokio",
 ]
 

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -17,8 +17,6 @@ tokio = { workspace = true, features = ["full"] }
 # Dependência opcional para simulação local
 anvil = { version = "0.3", optional = true }
 
-[dev-dependencies]
-serde_json = { workspace = true }
 
 [features]
 default = []

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -17,6 +17,9 @@ tokio = { workspace = true, features = ["full"] }
 # Dependência opcional para simulação local
 anvil = { version = "0.3", optional = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [features]
 default = []
 anvil = ["dep:anvil"]

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -20,3 +20,4 @@ anvil = { version = "0.3", optional = true }
 [features]
 default = []
 anvil = ["dep:anvil"]
+

--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -18,4 +18,6 @@ as estruturas de dados. Assim o código fica organizado e fácil de manter.
 O código expõe funções assíncronas e pode ser extendido com novos métodos de avaliação.
 
 
-Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de comando. Para executá-lo, habilite a feature `anvil`.
+Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de
+comando. O utilitário lê uma transação de um arquivo JSON. Lembre-se de
+habilitar a feature `anvil` ao compilar.

--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -19,5 +19,5 @@ O código expõe funções assíncronas e pode ser extendido com novos métodos 
 
 
 Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de
-comando. O utilitário lê uma transação de um arquivo JSON. Lembre-se de
-habilitar a feature `anvil` ao compilar.
+comando. O utilitário recebe um hash de transação e busca os dados em um node
+RPC. Lembre-se de habilitar a feature `anvil` ao compilar.

--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -17,3 +17,5 @@ as estruturas de dados. Assim o código fica organizado e fácil de manter.
 
 O código expõe funções assíncronas e pode ser extendido com novos métodos de avaliação.
 
+
+Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de comando.

--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -18,4 +18,4 @@ as estruturas de dados. Assim o código fica organizado e fácil de manter.
 O código expõe funções assíncronas e pode ser extendido com novos métodos de avaliação.
 
 
-Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de comando.
+Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de comando. Para executá-lo, habilite a feature `anvil`.

--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -1,0 +1,11 @@
+# Exemplos - sandwich-victim
+
+Este exemplo demonstra como utilizar a crate para analisar uma transação e verificar se ela pode ser vítima de um ataque *sandwich*.
+
+Execute o exemplo informando o endpoint RPC e o hash da transação que deseja analisar:
+
+```bash
+cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
+```
+
+O programa obtém os dados da transação via RPC, executa-a em um fork local com o `anvil` e imprime as métricas calculadas.

--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -2,7 +2,7 @@
 
 Este exemplo demonstra como utilizar a crate para analisar uma transação e verificar se ela pode ser vítima de um ataque *sandwich*.
 
-Execute o exemplo informando o endpoint RPC e o hash da transação que deseja analisar:
+Execute o exemplo informando o endpoint RPC e o hash da transação que deseja analisar. Certifique-se de habilitar a feature `anvil`:
 
 ```bash
 cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>

--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -1,11 +1,30 @@
 # Exemplos - sandwich-victim
 
-Este exemplo demonstra como utilizar a crate para analisar uma transação e verificar se ela pode ser vítima de um ataque *sandwich*.
+Este diretório contém um pequeno utilitário de linha de comando para
+analisar uma transação e verificar se ela é potencial vítima de um ataque
+*sandwich*.
 
-Execute o exemplo informando o endpoint RPC e o hash da transação que deseja analisar. Certifique-se de habilitar a feature `anvil`:
+Primeiro crie um arquivo JSON descrevendo a transação que deseja inspecionar.
+O formato segue a estrutura de `TransactionData` da biblioteca, por exemplo:
 
-```bash
-cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
+```json
+{
+  "from": "0x...",
+  "to": "0x...",
+  "data": "0x...",
+  "value": "0x0",
+  "gas": 21000,
+  "gas_price": "0x0",
+  "nonce": "0x0"
+}
 ```
 
-O programa obtém os dados da transação via RPC, executa-a em um fork local com o `anvil` e imprime as métricas calculadas.
+Em seguida execute o exemplo informando o endpoint RPC e o caminho do arquivo.
+Não se esqueça de habilitar a feature `anvil`:
+
+```bash
+cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <arquivo.json>
+```
+
+O programa carrega os dados do arquivo, executa a transação em um fork local
+com o `anvil` e imprime as métricas calculadas.

--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -4,27 +4,12 @@ Este diretório contém um pequeno utilitário de linha de comando para
 analisar uma transação e verificar se ela é potencial vítima de um ataque
 *sandwich*.
 
-Primeiro crie um arquivo JSON descrevendo a transação que deseja inspecionar.
-O formato segue a estrutura de `TransactionData` da biblioteca, por exemplo:
-
-```json
-{
-  "from": "0x...",
-  "to": "0x...",
-  "data": "0x...",
-  "value": "0x0",
-  "gas": 21000,
-  "gas_price": "0x0",
-  "nonce": "0x0"
-}
-```
-
-Em seguida execute o exemplo informando o endpoint RPC e o caminho do arquivo.
-Não se esqueça de habilitar a feature `anvil`:
+Informe um endpoint RPC e o hash de uma transação já incluída em bloco. O
+utilitário buscará os dados necessários no node e executará a análise.
 
 ```bash
-cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <arquivo.json>
+cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
 ```
 
-O programa carrega os dados do arquivo, executa a transação em um fork local
-com o `anvil` e imprime as métricas calculadas.
+O programa obtém os dados da transação e a executa em um fork local com o
+`anvil`, imprimindo as métricas calculadas.

--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::str::FromStr;
+
+use sandwich_victim::analysis::analyze_transaction;
+use sandwich_victim::types::TransactionData;
+use ethers::prelude::*;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("Uso: {} <RPC_ENDPOINT> <TX_HASH>", args[0]);
+        eprintln!("Exemplo: {} https://mainnet.infura.io/v3/YOURKEY 0x...", args[0]);
+        std::process::exit(1);
+    }
+
+    let rpc = args[1].clone();
+    let tx_hash = H256::from_str(&args[2])?;
+
+    let provider = Provider::<Http>::try_from(rpc.clone())?.interval(Duration::from_millis(100));
+    let fetched = provider
+        .get_transaction(tx_hash)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("transação não encontrada"))?;
+
+    let to = fetched.to.ok_or_else(|| anyhow::anyhow!("campo 'to' ausente"))?;
+    let tx = TransactionData {
+        from: fetched.from,
+        to,
+        data: fetched.input.0.to_vec(),
+        value: fetched.value,
+        gas: fetched.gas.as_u64(),
+        gas_price: fetched.gas_price.unwrap_or_default(),
+        nonce: fetched.nonce.into(),
+    };
+
+    let result = analyze_transaction(rpc, tx).await?;
+
+    println!("Potencial vítima: {}", result.potential_victim);
+    println!("Economicamente viável: {}", result.economically_viable);
+    println!("Slippage: {:.4}", result.metrics.slippage);
+    println!("Router: {:?}", result.metrics.router_name);
+    println!("Rota de tokens: {:?}", result.metrics.token_route);
+    if let Some(hash) = result.simulated_tx {
+        println!("Tx simulada: {hash:?}");
+    }
+
+    Ok(())
+}

--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -1,9 +1,9 @@
-//! Analisa uma transação fornecida em um arquivo JSON utilizando um endpoint RPC.
+//! Analisa uma transação identificada por um hash utilizando um endpoint RPC.
 //!
 //! É necessário compilar com a feature `anvil`:
 //!
 //! ```bash
-//! cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <ARQUIVO_JSON>
+//! cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
 //! ```
 
 #![cfg_attr(not(feature = "anvil"), allow(unused))]
@@ -12,23 +12,42 @@
 compile_error!("Este exemplo requer a feature 'anvil'. Utilize --features anvil");
 
 use std::env;
-use std::fs;
+use std::time::Duration;
 
 use sandwich_victim::analysis::analyze_transaction;
 use sandwich_victim::types::TransactionData;
+use ethers::prelude::*;
+use anyhow::anyhow;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 3 {
-        eprintln!("Uso: {} <RPC_ENDPOINT> <ARQUIVO_JSON>", args[0]);
-        eprintln!("Exemplo: {} https://mainnet.infura.io/v3/YOURKEY tx.json", args[0]);
+        eprintln!("Uso: {} <RPC_ENDPOINT> <TX_HASH>", args[0]);
+        eprintln!("Exemplo: {} https://mainnet.infura.io/v3/YOURKEY 0x...", args[0]);
         std::process::exit(1);
     }
 
     let rpc = args[1].clone();
-    let json = fs::read_to_string(&args[2])?;
-    let tx: TransactionData = serde_json::from_str(&json)?;
+    let tx_hash: H256 = args[2].parse()?;
+
+    let provider = Provider::<Http>::try_from(rpc.clone())?.interval(Duration::from_millis(100));
+    let fetched = provider
+        .get_transaction(tx_hash)
+        .await?
+        .ok_or_else(|| anyhow!("transação não encontrada"))?;
+
+    let to = fetched.to.ok_or_else(|| anyhow!("transação sem destinatário"))?;
+
+    let tx = TransactionData {
+        from: fetched.from,
+        to,
+        data: fetched.input.to_vec(),
+        value: fetched.value,
+        gas: fetched.gas.as_u64(),
+        gas_price: fetched.gas_price.unwrap_or_default(),
+        nonce: fetched.nonce,
+    };
 
     let result = analyze_transaction(rpc, tx).await?;
 

--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -1,3 +1,16 @@
+//! Analisa uma transação buscada por hash em um endpoint RPC.
+//!
+//! É necessário compilar com a feature `anvil`:
+//!
+//! ```bash
+//! cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
+//! ```
+
+#![cfg_attr(not(feature = "anvil"), allow(unused))]
+
+#[cfg(not(feature = "anvil"))]
+compile_error!("Este exemplo requer a feature 'anvil'. Utilize --features anvil");
+
 use std::env;
 use std::str::FromStr;
 

--- a/crates/sandwich-victim/src/simulation.rs
+++ b/crates/sandwich-victim/src/simulation.rs
@@ -43,8 +43,7 @@ pub async fn simulate_transaction(
             .data(tx.data.clone())
             .value(tx.value)
             .gas(tx.gas)
-            .gas_price(tx.gas_price)
-            .nonce(tx.nonce);
+            .gas_price(tx.gas_price);
 
         let pending = provider.send_transaction(tx_request, None).await?;
         let receipt = pending

--- a/crates/sandwich-victim/src/simulation.rs
+++ b/crates/sandwich-victim/src/simulation.rs
@@ -24,7 +24,7 @@ pub async fn simulate_transaction(
 ) -> Result<SimulationOutcome> {
     #[cfg(feature = "anvil")]
     {
-        use anvil::Anvil;
+        use ethers::utils::Anvil;
 
         let anvil = Anvil::new()
             .fork(config.rpc_endpoint.clone())
@@ -46,7 +46,8 @@ pub async fn simulate_transaction(
                 None,
             )
             .await?;
-        let receipt = pending.await?;
+        let receipt = pending.await?
+            .ok_or_else(|| anyhow!("transação não minerada"))?;
         Ok(SimulationOutcome {
             tx_hash: Some(receipt.transaction_hash),
             logs: receipt.logs,


### PR DESCRIPTION
## Summary
- adjust example CLI to fetch a transaction by hash
- update example README for new usage
- drop unused serde_json dev dependency

## Testing
- `cargo check -p sandwich-victim --examples --features anvil`


------
https://chatgpt.com/codex/tasks/task_e_685f4837e5dc833294237085c5ab6920