### PR TITLE
Improve local simulation setup

### DIFF
--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -14,11 +14,10 @@ ethereum-types = { workspace = true }
 ethers = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
-# Dependência opcional para simulação local
-anvil = { version = "0.3", optional = true }
+# Dependência para simulação local
+anvil = "0.3"
 
 
 [features]
 default = []
-anvil = ["dep:anvil"]
 

--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -20,4 +20,4 @@ O código expõe funções assíncronas e pode ser extendido com novos métodos 
 
 Consulte o diretório [examples](./examples/) para um exemplo de uso via linha de
 comando. O utilitário recebe um hash de transação e busca os dados em um node
-RPC. Lembre-se de habilitar a feature `anvil` ao compilar.
+RPC executando a simulação automaticamente com o `anvil`.

--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -8,7 +8,7 @@ Informe um endpoint RPC e o hash de uma transação já incluída em bloco. O
 utilitário buscará os dados necessários no node e executará a análise.
 
 ```bash
-cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
+cargo run -p sandwich-victim --example analyze_tx -- <RPC_ENDPOINT> <TX_HASH>
 ```
 
 O programa obtém os dados da transação e a executa em um fork local com o

--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -1,15 +1,10 @@
 //! Analisa uma transação identificada por um hash utilizando um endpoint RPC.
 //!
-//! É necessário compilar com a feature `anvil`:
+//! Uso:
 //!
 //! ```bash
-//! cargo run -p sandwich-victim --example analyze_tx --features anvil -- <RPC_ENDPOINT> <TX_HASH>
+//! cargo run -p sandwich-victim --example analyze_tx -- <RPC_ENDPOINT> <TX_HASH>
 //! ```
-
-#![cfg_attr(not(feature = "anvil"), allow(unused))]
-
-#[cfg(not(feature = "anvil"))]
-compile_error!("Este exemplo requer a feature 'anvil'. Utilize --features anvil");
 
 use std::env;
 use std::time::Duration;

--- a/crates/sandwich-victim/src/analysis/mod.rs
+++ b/crates/sandwich-victim/src/analysis/mod.rs
@@ -17,7 +17,10 @@ pub async fn analyze_transaction(rpc_endpoint: String, tx: TransactionData) -> R
     let provider = Provider::<Http>::try_from(rpc_endpoint.clone())?.interval(Duration::from_millis(100));
     let router: RouterInfo = identify_router(&provider, tx.to).await?;
 
-    let sim_config = SimulationConfig { rpc_endpoint };
+    let sim_config = SimulationConfig {
+        rpc_endpoint,
+        block_number: None,
+    };
     let SimulationOutcome { tx_hash, logs } = simulate_transaction(&sim_config, &tx).await?;
 
     let (swap_kind, function) = detect_swap_function(&tx.data)


### PR DESCRIPTION
## Summary
- remove feature flag for `anvil`
- expose `block_number` on simulation configuration
- improve error handling in simulation
- adjust analysis and examples

## Testing
- `cargo check -p sandwich-victim --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686019a156a88332ac0862769faf321b