### PR TITLE
Improve router detection using logs

### DIFF
--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -6,7 +6,7 @@ Biblioteca para detectar oportunidades de ataque *sandwich* em transações Ethe
 - slippage real comparado com a cotação esperada
 - quantidade mínima de tokens capaz de afetar o preço
 - lucro potencial de uma estratégia de front‑run e back‑run
-- identificação dinâmica do router envolvido
+- identificação dinâmica do router envolvido (extraído exclusivamente dos logs da simulação)
 - reconhecimento de todas as variações de funções de swap V2
 
 A arquitetura segue o princípio de responsabilidade única. Cada módulo possui

--- a/crates/sandwich-victim/src/dex/mod.rs
+++ b/crates/sandwich-victim/src/dex/mod.rs
@@ -2,6 +2,6 @@ pub mod router;
 pub mod decoder;
 pub mod query;
 
-pub use router::{identify_router, RouterInfo};
+pub use router::{identify_router, router_from_logs, RouterInfo};
 pub use decoder::{detect_swap_function, SwapFunction};
 pub use query::{get_pair_address, get_pair_reserves};


### PR DESCRIPTION
## Summary
- rely entirely on simulation logs for router discovery
- drop hardcoded Uniswap/Sushi router bytes
- error out when router address cannot be extracted
- update documentation about log-based identification

## Testing
- `cargo check --workspace --quiet`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6860325768cc8332a70838b72e89c920