### PR TITLE
Add router identification tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ version = "0.1.0"
 dependencies = [
  "anvil",
  "anyhow",
+ "async-trait",
  "dashmap",
  "ethereum-types",
  "ethernity-core",

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -22,6 +22,9 @@ ethernity-rpc = { path = "../ethernity-rpc" }
 
 # Dependência para simulação local
 anvil = "0.3"
+[dev-dependencies]
+async-trait = { workspace = true }
+
 
 
 [features]

--- a/crates/sandwich-victim/src/dex/router.rs
+++ b/crates/sandwich-victim/src/dex/router.rs
@@ -68,3 +68,104 @@ pub fn router_from_logs(logs: &[Log]) -> Option<Address> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ethernity_core::error::{Result as CoreResult, Error};
+    use ethernity_core::traits::RpcProvider;
+    use ethernity_core::types::TransactionHash;
+
+    struct DummyProvider {
+        factory: Option<Address>,
+    }
+
+    #[async_trait]
+    impl RpcProvider for DummyProvider {
+        async fn get_transaction_trace(&self, _tx_hash: TransactionHash) -> CoreResult<Vec<u8>> {
+            Ok(vec![])
+        }
+
+        async fn get_transaction_receipt(&self, _tx_hash: TransactionHash) -> CoreResult<Vec<u8>> {
+            Ok(vec![])
+        }
+
+        async fn get_code(&self, _address: Address) -> CoreResult<Vec<u8>> {
+            Ok(vec![])
+        }
+
+        async fn call(&self, _to: Address, data: Vec<u8>) -> CoreResult<Vec<u8>> {
+            // factory() encoded call has only 4 bytes
+            if data.len() == 4 {
+                if let Some(addr) = self.factory {
+                    let mut out = vec![0u8; 32];
+                    out[12..].copy_from_slice(addr.as_bytes());
+                    Ok(out)
+                } else {
+                    Err(Error::RpcError("not found".into()))
+                }
+            } else {
+                Ok(vec![])
+            }
+        }
+
+        async fn get_block_number(&self) -> CoreResult<u64> {
+            Ok(0)
+        }
+
+        async fn get_block_hash(&self, _block_number: u64) -> CoreResult<H256> {
+            Ok(H256::zero())
+        }
+    }
+
+    #[test]
+    fn extract_router_from_logs() {
+        let router = Address::from_low_u64_be(42);
+        let swap_sig = H256::from_slice(
+            keccak256("Swap(address,uint256,uint256,uint256,uint256,address)").as_slice(),
+        );
+        let log = Log { topics: vec![swap_sig, router.into()], ..Default::default() };
+
+        assert_eq!(router_from_logs(&[log]), Some(router));
+    }
+
+    #[test]
+    fn router_from_logs_none() {
+        let log = Log::default();
+        assert_eq!(router_from_logs(&[log]), None);
+    }
+
+    #[tokio::test]
+    async fn identify_router_returns_factory() {
+        let factory = Address::from_low_u64_be(1);
+        let provider = DummyProvider { factory: Some(factory) };
+        let router = Address::from_low_u64_be(2);
+
+        let info = identify_router(&provider, router).await.unwrap();
+        assert_eq!(info.address, router);
+        assert_eq!(info.factory, Some(factory));
+    }
+
+    #[tokio::test]
+    async fn identify_router_no_factory() {
+        let provider = DummyProvider { factory: None };
+        let router = Address::from_low_u64_be(3);
+
+        let info = identify_router(&provider, router).await.unwrap();
+        assert_eq!(info.address, router);
+        assert_eq!(info.factory, None);
+    }
+
+    #[test]
+    fn router_from_logs_multiple_entries() {
+        let other_log = Log::default();
+        let router = Address::from_low_u64_be(55);
+        let swap_sig = H256::from_slice(
+            keccak256("Swap(address,uint256,uint256,uint256,uint256,address)").as_slice(),
+        );
+        let swap_log = Log { topics: vec![swap_sig, router.into()], ..Default::default() };
+
+        assert_eq!(router_from_logs(&[other_log, swap_log]), Some(router));
+    }
+}


### PR DESCRIPTION
## Summary
- implement unit tests for router identification logic in the `sandwich-victim` crate
- add `async-trait` as dev-dependency for testing
- expand tests with cases for missing factory and multiple logs

## Testing
- `cargo test -p sandwich-victim -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6860386b8f84833298427ef058c095aa