### PR TITLE
Add mempool monitoring example

### DIFF
--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -18,6 +18,7 @@ dashmap = { workspace = true }
 rlp = "0.5"
 parking_lot = { workspace = true }
 serde_json = { workspace = true }
+futures = { workspace = true }
 ethernity-core = { path = "../ethernity-core" }
 ethernity-rpc = { path = "../ethernity-rpc" }
 

--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -13,3 +13,13 @@ cargo run -p sandwich-victim --example analyze_tx -- <RPC_ENDPOINT> <TX_HASH>
 
 O programa obtém os dados da transação e a executa em um fork local com o
 `anvil`, imprimindo as métricas calculadas.
+
+## Monitorar o mempool via WebSocket
+
+Este exemplo conecta-se a um endpoint RPC WebSocket e escuta as transações pendentes do mempool. Cada transação é analisada e, se houver indícios de que seja uma potencial vítima de *sandwich*, as métricas são exibidas no console.
+
+```bash
+cargo run -p sandwich-victim --example mempool_watch -- <WS_RPC_ENDPOINT>
+```
+
+Certifique-se de utilizar um node completo que ofereça o método `newPendingTransactions` via WebSocket.

--- a/crates/sandwich-victim/examples/mempool_watch.rs
+++ b/crates/sandwich-victim/examples/mempool_watch.rs
@@ -1,0 +1,73 @@
+use std::env;
+use std::time::Duration;
+
+use anyhow::Result;
+use ethernity_rpc::{EthernityRpcClient, RpcConfig};
+use ethers::prelude::*;
+use futures::StreamExt;
+use sandwich_victim::core::analyze_transaction;
+use sandwich_victim::types::TransactionData;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Uso: {} <WS_RPC_ENDPOINT>", args[0]);
+        eprintln!("Exemplo: {} ws://localhost:8546", args[0]);
+        std::process::exit(1);
+    }
+
+    let ws_url = args[1].clone();
+    let ws = Ws::connect(ws_url.clone()).await?;
+    let provider = Provider::new(ws).interval(Duration::from_millis(1000));
+
+    let rpc_client = Arc::new(
+        EthernityRpcClient::new(RpcConfig {
+            endpoint: ws_url.clone(),
+            ..Default::default()
+        })
+        .await?,
+    );
+
+    let mut stream = provider
+        .subscribe_pending_txs()
+        .await?
+        .transactions_unordered(10);
+    println!("Escutando transações pendentes...");
+
+    while let Some(res) = stream.next().await {
+        let tx = match res {
+            Ok(tx) => tx,
+            Err(err) => {
+                eprintln!("Erro ao obter transação: {err}");
+                continue;
+            }
+        };
+        let Some(to) = tx.to else { continue };
+        let tx_data = TransactionData {
+            from: tx.from,
+            to,
+            data: tx.input.to_vec(),
+            value: tx.value,
+            gas: tx.gas.as_u64(),
+            gas_price: tx.gas_price.unwrap_or_default(),
+            nonce: tx.nonce,
+        };
+
+        match analyze_transaction(rpc_client.clone(), ws_url.clone(), tx_data, None).await {
+            Ok(result) if result.potential_victim => {
+                println!("Possível vítima: {:?}", tx.hash);
+                println!("Slippage: {:.4}", result.metrics.slippage);
+                println!("Router: {:?}", result.metrics.router_name);
+                println!("Rota de tokens: {:?}", result.metrics.token_route);
+            }
+            Ok(_) => {}
+            Err(err) => {
+                eprintln!("Falha ao analisar tx {:?}: {err}", tx.hash);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement `mempool_watch` example that connects via WebSocket and analyzes pending transactions
- document the new example in examples README
- add `futures` dependency for the example

## Testing
- `cargo check --examples -p sandwich-victim`
- `cargo test -p sandwich-victim -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6861ada6bab08332a376729dc25e3cc7