### PR TITLE
Implement filter pipeline for simulations

### DIFF
--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -46,8 +46,24 @@ async fn main() -> anyhow::Result<()> {
         nonce: fetched.nonce,
     };
 
-    let rpc_client = Arc::new(EthernityRpcClient::new(RpcConfig { endpoint: rpc.clone(), ..Default::default() }).await?);
-    let result = analyze_transaction(rpc_client, rpc, tx, fetched.block_number.map(|b| b.as_u64() - 1)).await?;
+    let rpc_client = Arc::new(EthernityRpcClient::new(RpcConfig {
+        endpoint: rpc.clone(),
+        ..Default::default()
+    })
+    .await?);
+
+    let Some(result) = analyze_transaction(
+        rpc_client,
+        rpc,
+        tx,
+        fetched.block_number.map(|b| b.as_u64() - 1),
+    )
+    .await?
+    else {
+        println!("Transação ignorada pelos filtros");
+        return Ok(());
+    };
+
     println!("Potencial vítima: {}", result.potential_victim);
     println!("Economicamente viável: {}", result.economically_viable);
     println!("Slippage: {:.4}", result.metrics.slippage);

--- a/crates/sandwich-victim/examples/mempool_watch.rs
+++ b/crates/sandwich-victim/examples/mempool_watch.rs
@@ -56,13 +56,14 @@ async fn main() -> Result<()> {
         };
 
         match analyze_transaction(rpc_client.clone(), ws_url.clone(), tx_data, None).await {
-            Ok(result) if result.potential_victim => {
+            Ok(Some(result)) if result.potential_victim => {
                 println!("Possível vítima: {:?}", tx.hash);
                 println!("Slippage: {:.4}", result.metrics.slippage);
                 println!("Router: {:?}", result.metrics.router_name);
                 println!("Rota de tokens: {:?}", result.metrics.token_route);
             }
-            Ok(_) => {}
+            Ok(Some(_)) => {}
+            Ok(None) => {}
             Err(err) => {
                 eprintln!("Falha ao analisar tx {:?}: {err}", tx.hash);
             }

--- a/crates/sandwich-victim/src/core/analyzer.rs
+++ b/crates/sandwich-victim/src/core/analyzer.rs
@@ -3,6 +3,7 @@ use crate::dex::{
     router_from_logs, RouterInfo, SwapFunction,
 };
 use crate::simulation::{simulate_transaction, SimulationConfig, SimulationOutcome};
+use crate::filters::{FilterPipeline, SwapLogFilter};
 use crate::types::{AnalysisResult, Metrics, TransactionData};
 use crate::core::metrics::{simulate_sandwich_profit, U256Ext};
 use anyhow::{anyhow, Result};
@@ -22,7 +23,7 @@ pub async fn analyze_transaction<P>(
     rpc_endpoint: String,
     tx: TransactionData,
     block: Option<u64>
-) -> Result<AnalysisResult>
+) -> Result<Option<AnalysisResult>>
 where
     P: RpcProvider + Send + Sync + 'static,
 {
@@ -30,8 +31,12 @@ where
         rpc_endpoint,
         block_number: block,
     };
-    println!("{:?}",sim_config);
-    let SimulationOutcome { tx_hash, logs } = simulate_transaction(&sim_config, &tx).await?;
+    let outcome = simulate_transaction(&sim_config, &tx).await?;
+    let outcome = match FilterPipeline::new().push(SwapLogFilter).run(outcome) {
+        Some(out) => out,
+        None => return Ok(None),
+    };
+    let SimulationOutcome { tx_hash, logs } = outcome;
 
     let router_address = router_from_logs(&logs)
         .ok_or_else(|| anyhow!("router não encontrado nos logs"))?;
@@ -203,10 +208,10 @@ where
         slippage > 0.0
     };
 
-    Ok(AnalysisResult {
+    Ok(Some(AnalysisResult {
         potential_victim,
         economically_viable: potential_profit > U256::zero(),
         simulated_tx: tx_hash,
         metrics,
-    })
+    }))
 }

--- a/crates/sandwich-victim/src/filters/mod.rs
+++ b/crates/sandwich-victim/src/filters/mod.rs
@@ -1,0 +1,95 @@
+use crate::simulation::SimulationOutcome;
+use ethers::types::H256;
+use std::str::FromStr;
+
+/// Trait para filtros de resultados de simulação
+pub trait Filter: Send + Sync {
+    /// Aplica o filtro ao resultado.
+    /// Retorna `Some` quando a simulação deve continuar no pipeline
+    /// ou `None` para descartar.
+    fn apply(&self, outcome: SimulationOutcome) -> Option<SimulationOutcome>;
+}
+
+/// Pipeline de filtros a serem executados sequencialmente
+#[derive(Default)]
+pub struct FilterPipeline {
+    filters: Vec<Box<dyn Filter>>,
+}
+
+impl FilterPipeline {
+    /// Cria pipeline vazio
+    pub fn new() -> Self {
+        Self { filters: Vec::new() }
+    }
+
+    /// Adiciona um filtro ao pipeline
+    pub fn push<F: Filter + 'static>(mut self, filter: F) -> Self {
+        self.filters.push(Box::new(filter));
+        self
+    }
+
+    /// Executa os filtros em sequência retornando o resultado final
+    pub fn run(&self, mut outcome: SimulationOutcome) -> Option<SimulationOutcome> {
+        for f in &self.filters {
+            match f.apply(outcome) {
+                Some(out) => outcome = out,
+                None => return None,
+            }
+        }
+        Some(outcome)
+    }
+}
+
+/// Filtro que verifica a presença do evento `Swap` nos logs
+pub struct SwapLogFilter;
+
+const SWAP_TOPIC: &str = "0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822";
+
+impl Filter for SwapLogFilter {
+    fn apply(&self, outcome: SimulationOutcome) -> Option<SimulationOutcome> {
+        let topic = H256::from_str(SWAP_TOPIC).expect("valid topic hex");
+        if outcome.logs.iter().any(|log| log.topics.get(0) == Some(&topic)) {
+            Some(outcome)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::types::{Address, Bytes, Log};
+
+    fn outcome_with_topics(topics: Vec<H256>) -> SimulationOutcome {
+        let log = Log {
+            address: Address::zero(),
+            topics,
+            data: Bytes::default(),
+            block_hash: None,
+            block_number: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            transaction_log_index: None,
+            log_type: None,
+            removed: None,
+        };
+        SimulationOutcome { tx_hash: None, logs: vec![log] }
+    }
+
+    #[test]
+    fn filter_passes_when_topic_present() {
+        let outcome = outcome_with_topics(vec![H256::from_str(SWAP_TOPIC).unwrap()]);
+        let pipeline = FilterPipeline::new().push(SwapLogFilter);
+        assert!(pipeline.run(outcome).is_some());
+    }
+
+    #[test]
+    fn filter_discards_when_topic_absent() {
+        let outcome = outcome_with_topics(vec![H256::zero()]);
+        let pipeline = FilterPipeline::new().push(SwapLogFilter);
+        assert!(pipeline.run(outcome).is_none());
+    }
+}
+

--- a/crates/sandwich-victim/src/lib.rs
+++ b/crates/sandwich-victim/src/lib.rs
@@ -8,3 +8,4 @@ pub mod types;
 pub mod simulation;
 pub mod dex;
 pub mod core;
+pub mod filters;


### PR DESCRIPTION
## Summary
- add `filters` module with trait `Filter` and `FilterPipeline`
- implement `SwapLogFilter` to discard simulations without the `Swap` event
- apply filter pipeline in the analyzer and return `None` when filtered out
- update examples to handle `Option<AnalysisResult>`

## Testing
- `cargo test -p sandwich-victim --no-run`
- `cargo test -p sandwich-victim -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6861b5821bd48332ae661963963a858f