### PR TITLE
Fix examples after analyzer API change

### DIFF
--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -52,17 +52,13 @@ async fn main() -> anyhow::Result<()> {
     })
     .await?);
 
-    let Some(result) = analyze_transaction(
+    let result = analyze_transaction(
         rpc_client,
         rpc,
         tx,
         fetched.block_number.map(|b| b.as_u64() - 1),
     )
-    .await?
-    else {
-        println!("Transação ignorada pelos filtros");
-        return Ok(());
-    };
+    .await?;
 
     println!("Potencial vítima: {}", result.potential_victim);
     println!("Economicamente viável: {}", result.economically_viable);

--- a/crates/sandwich-victim/examples/mempool_watch.rs
+++ b/crates/sandwich-victim/examples/mempool_watch.rs
@@ -56,14 +56,13 @@ async fn main() -> Result<()> {
         };
 
         match analyze_transaction(rpc_client.clone(), ws_url.clone(), tx_data, None).await {
-            Ok(Some(result)) if result.potential_victim => {
+            Ok(result) if result.potential_victim => {
                 println!("Possível vítima: {:?}", tx.hash);
                 println!("Slippage: {:.4}", result.metrics.slippage);
                 println!("Router: {:?}", result.metrics.router_name);
                 println!("Rota de tokens: {:?}", result.metrics.token_route);
             }
-            Ok(Some(_)) => {}
-            Ok(None) => {}
+            Ok(_) => {}
             Err(err) => {
                 eprintln!("Falha ao analisar tx {:?}: {err}", tx.hash);
             }


### PR DESCRIPTION
## Summary
- update `analyze_tx` and `mempool_watch` examples to match `analyze_transaction` return type

## Testing
- `cargo check -p sandwich-victim --examples`
- `cargo test -p sandwich-victim`

------
https://chatgpt.com/codex/tasks/task_e_6861c9b9e0f0833292baa7ca85fc578b