### PR TITLE
Refactor sandwich victim analyzer with modular detectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,6 +3356,7 @@ dependencies = [
  "ethernity-core",
  "ethernity-rpc",
  "ethers",
+ "futures",
  "parking_lot",
  "rlp",
  "serde",

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -21,11 +21,11 @@ serde_json = { workspace = true }
 futures = { workspace = true }
 ethernity-core = { path = "../ethernity-core" }
 ethernity-rpc = { path = "../ethernity-rpc" }
+async-trait = { workspace = true }
 
 # Dependência para simulação local
 anvil = "0.3"
 [dev-dependencies]
-async-trait = { workspace = true }
 
 
 

--- a/crates/sandwich-victim/src/core/analyzer.rs
+++ b/crates/sandwich-victim/src/core/analyzer.rs
@@ -1,23 +1,11 @@
-use crate::dex::{
-    detect_swap_function, get_pair_address, identify_router,
-    router_from_logs, RouterInfo, SwapFunction,
-};
-use crate::simulation::{simulate_transaction, SimulationConfig, SimulationOutcome};
+use crate::detectors::{DetectorRegistry};
+use crate::dex::{identify_router, router_from_logs, RouterInfo};
 use crate::filters::{FilterPipeline, SwapLogFilter};
-use crate::types::{AnalysisResult, Metrics, TransactionData};
-use crate::core::metrics::{simulate_sandwich_profit, U256Ext};
-use anyhow::{anyhow, Result};
-use ethers::abi::{AbiParser, Token};
-use ethers::utils::keccak256;
-use ethers::prelude::{Provider, Http, Middleware, TransactionRequest};
-use ethers::types::BlockId;
-use std::time::Duration;
+use crate::simulation::{simulate_transaction, SimulationConfig};
+use crate::types::{AnalysisResult, TransactionData};
+use anyhow::{Result, anyhow};
 use ethernity_core::traits::RpcProvider;
 use std::sync::Arc;
-use ethereum_types::{Address, U256, H256};
-
-// Primeiro, defina um enum para seus erros (coloque isso no início do arquivo ou em um módulo de erros)
-use std::error::Error as StdError;
 
 #[derive(Debug, thiserror::Error)]
 enum AnalysisError {
@@ -25,211 +13,34 @@ enum AnalysisError {
     NoSwapEvent,
     #[error("Router not found in logs")]
     NoRouterFound,
-    #[error("Unrecognized swap function")]
-    UnrecognizedSwap,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 
-// Agora o AnalysisError implementa automaticamente Error através do thiserror
-
-
-pub async fn analyze_transaction<P>(
-    rpc_client: Arc<P>,
+pub async fn analyze_transaction(
+    rpc_client: Arc<dyn RpcProvider>,
     rpc_endpoint: String,
     tx: TransactionData,
-    block: Option<u64>
-) -> Result<AnalysisResult>
-where
-    P: RpcProvider + Send + Sync + 'static,
-{
+    block: Option<u64>,
+) -> Result<AnalysisResult> {
     let sim_config = SimulationConfig {
-        rpc_endpoint,
+        rpc_endpoint: rpc_endpoint.clone(),
         block_number: block,
     };
 
     let outcome = simulate_transaction(&sim_config, &tx).await?;
-    // Então modifique as linhas que usam anyhow para usar seu próprio tipo de erro
     let outcome = FilterPipeline::new()
         .push(SwapLogFilter)
         .run(outcome)
         .ok_or(AnalysisError::NoSwapEvent)?;
-    let SimulationOutcome { tx_hash, logs } = outcome;
 
-    let router_address = router_from_logs(&logs)
-        .ok_or(AnalysisError::NoRouterFound)?;
+    let router_address = router_from_logs(&outcome.logs).ok_or(AnalysisError::NoRouterFound)?;
     let router: RouterInfo = identify_router(&*rpc_client, router_address).await?;
 
-    let (swap_kind, function) = detect_swap_function(&tx.data)
-        .ok_or(AnalysisError::UnrecognizedSwap)?;
-    let tokens = function.decode_input(&tx.data[4..])?;
-
-    let (amount_in, amount_out, amount_in_max, amount_out_min, path) = match swap_kind {
-        SwapFunction::SwapExactTokensForTokens
-        | SwapFunction::SwapExactTokensForETH
-        | SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens
-        | SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens => {
-            let amount_in = tokens[0].clone().into_uint().unwrap();
-            let amount_out_min = tokens[1].clone().into_uint().unwrap();
-            let path: Vec<Address> = tokens[2]
-                .clone()
-                .into_array()
-                .unwrap()
-                .into_iter()
-                .map(|t| t.into_address().unwrap())
-                .collect();
-            (Some(amount_in), None, None, Some(amount_out_min), path)
-        }
-        SwapFunction::SwapTokensForExactTokens | SwapFunction::SwapTokensForExactETH => {
-            let amount_out = tokens[0].clone().into_uint().unwrap();
-            let amount_in_max = tokens[1].clone().into_uint().unwrap();
-            let path: Vec<Address> = tokens[2]
-                .clone()
-                .into_array()
-                .unwrap()
-                .into_iter()
-                .map(|t| t.into_address().unwrap())
-                .collect();
-            (None, Some(amount_out), Some(amount_in_max), None, path)
-        }
-        SwapFunction::SwapExactETHForTokens
-        | SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens => {
-            let amount_out_min = tokens[0].clone().into_uint().unwrap();
-            let path: Vec<Address> = tokens[1]
-                .clone()
-                .into_array()
-                .unwrap()
-                .into_iter()
-                .map(|t| t.into_address().unwrap())
-                .collect();
-            (Some(tx.value), None, None, Some(amount_out_min), path)
-        }
-        SwapFunction::ETHForExactTokens => {
-            let amount_out = tokens[0].clone().into_uint().unwrap();
-            let path: Vec<Address> = tokens[1]
-                .clone()
-                .into_array()
-                .unwrap()
-                .into_iter()
-                .map(|t| t.into_address().unwrap())
-                .collect();
-            (None, Some(amount_out), Some(tx.value), None, path)
-        }
-    };
-
-    let path_tokens: Vec<Token> = path.iter().map(|a| Token::Address(*a)).collect();
-
-    let provider = Provider::<Http>::try_from(sim_config.rpc_endpoint.clone())?
-        .interval(Duration::from_millis(1));
-
-    let (expected_out, expected_in) = if let Some(a_in) = amount_in {
-        let abi = AbiParser::default()
-            .parse_function("getAmountsOut(uint256,address[]) returns (uint256[])")?;
-        let data = abi.encode_input(&[Token::Uint(a_in), Token::Array(path_tokens.clone())])?;
-        let tx_call = TransactionRequest::new().to(router.address).data(data.clone());
-        let call = provider
-            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
-            .await
-            .map_err(|e| anyhow!(e))?;
-        let out_tokens = abi.decode_output(&call)?;
-        let out = out_tokens[0].clone().into_array().unwrap().last().unwrap().clone().into_uint().unwrap();
-        (Some(out), None)
-    } else if let Some(a_out) = amount_out {
-        let abi = AbiParser::default()
-            .parse_function("getAmountsIn(uint256,address[]) returns (uint256[])")?;
-        let data = abi.encode_input(&[Token::Uint(a_out), Token::Array(path_tokens.clone())])?;
-        let tx_call = TransactionRequest::new().to(router.address).data(data.clone());
-        let call = provider
-            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
-            .await
-            .map_err(|e| anyhow!(e))?;
-        let in_tokens = abi.decode_output(&call)?;
-        let inp = in_tokens[0].clone().into_array().unwrap().first().unwrap().clone().into_uint().unwrap();
-        (None, Some(inp))
-    } else {
-        (None, None)
-    };
-
-    let transfer_sig: H256 =
-        H256::from_slice(keccak256("Transfer(address,address,uint256)").as_slice());
-    let mut actual_out = U256::zero();
-    let mut actual_in = U256::zero();
-    for log in &logs {
-        if log.topics.get(0) == Some(&transfer_sig) && log.topics.len() == 3 {
-            let from_addr = Address::from_slice(&log.topics[1].as_bytes()[12..]);
-            let to_addr = Address::from_slice(&log.topics[2].as_bytes()[12..]);
-            if to_addr == tx.from {
-                actual_out = U256::from_big_endian(&log.data.0);
-            }
-            if from_addr == tx.from {
-                actual_in = U256::from_big_endian(&log.data.0);
-            }
-        }
-    }
-
-    let slippage = if let Some(exp_out) = expected_out {
-        if exp_out > actual_out {
-            (exp_out - actual_out).to_f64_lossy() / exp_out.to_f64_lossy()
-        } else {
-            0.0
-        }
-    } else if let Some(exp_in) = expected_in {
-        if actual_in > exp_in {
-            (actual_in - exp_in).to_f64_lossy() / exp_in.to_f64_lossy()
-        } else {
-            0.0
-        }
-    } else {
-        0.0
-    };
-
-    let pair_address = if let Some(factory) = router.factory {
-        get_pair_address(&*rpc_client, factory, path[0], path[1]).await?
-    } else {
-        return Err(anyhow!("router não fornece fábrica"));
-    };
-
-    let (reserve_in, reserve_out) = {
-        let abi = AbiParser::default()
-            .parse_function("getReserves() returns (uint112,uint112,uint32)")?;
-        let data = abi.encode_input(&[])?;
-        let tx_call = TransactionRequest::new().to(pair_address).data(data);
-        let call = provider
-            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
-            .await
-            .map_err(|e| anyhow!(e))?;
-        let tokens = abi.decode_output(&call)?;
-        (
-            tokens[0].clone().into_uint().unwrap(),
-            tokens[1].clone().into_uint().unwrap(),
-        )
-    };
-    let min_tokens_to_affect = reserve_in / U256::from(100u64);
-    let input_for_profit = amount_in.unwrap_or(actual_in);
-    let potential_profit = simulate_sandwich_profit(input_for_profit, reserve_in, reserve_out);
-
-    let metrics = Metrics {
-        swap_function: swap_kind,
-        token_route: path.clone(),
-        slippage,
-        min_tokens_to_affect,
-        potential_profit,
-        router_address: router.address,
-        router_name: router.name.clone(),
-    };
-
-    let potential_victim = if let Some(out_min) = amount_out_min {
-        slippage > 0.0 && expected_out.unwrap_or(U256::zero()) >= out_min
-    } else if let Some(in_max) = amount_in_max {
-        slippage > 0.0 && actual_in <= in_max
-    } else {
-        slippage > 0.0
-    };
-
-    Ok(AnalysisResult {
-        potential_victim,
-        economically_viable: potential_profit > U256::zero(),
-        simulated_tx: tx_hash,
-        metrics,
-    })
+    let registry = DetectorRegistry::default();
+    registry
+        .analyze(rpc_client, rpc_endpoint, tx, block, outcome, router)
+        .await
+        .map_err(|e| anyhow!(e))
 }
+

--- a/crates/sandwich-victim/src/detectors/mod.rs
+++ b/crates/sandwich-victim/src/detectors/mod.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use crate::types::{AnalysisResult, TransactionData};
+use crate::simulation::SimulationOutcome;
+use crate::dex::RouterInfo;
+use ethernity_core::traits::RpcProvider;
+use std::sync::Arc;
+use anyhow::Result;
+
+pub mod uniswap_v2;
+use uniswap_v2::UniswapV2Detector;
+
+#[async_trait]
+pub trait VictimDetector: Send + Sync {
+    fn supports(&self, router: &RouterInfo) -> bool;
+    async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        outcome: SimulationOutcome,
+        router: RouterInfo,
+    ) -> Result<AnalysisResult>;
+}
+
+pub struct DetectorRegistry {
+    detectors: Vec<Box<dyn VictimDetector>>,
+}
+
+impl Default for DetectorRegistry {
+    fn default() -> Self {
+        Self { detectors: vec![Box::new(UniswapV2Detector)] }
+    }
+}
+
+impl DetectorRegistry {
+    pub async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        outcome: SimulationOutcome,
+        router: RouterInfo,
+    ) -> Result<AnalysisResult> {
+        for d in &self.detectors {
+            if d.supports(&router) {
+                return d
+                    .analyze(rpc_client.clone(), rpc_endpoint.clone(), tx.clone(), block, outcome.clone(), router.clone())
+                    .await;
+            }
+        }
+        Err(anyhow::anyhow!("unsupported router"))
+    }
+}
+

--- a/crates/sandwich-victim/src/detectors/uniswap_v2.rs
+++ b/crates/sandwich-victim/src/detectors/uniswap_v2.rs
@@ -1,0 +1,233 @@
+use crate::dex::{detect_swap_function, get_pair_address, RouterInfo, SwapFunction};
+use crate::simulation::{simulate_transaction, SimulationConfig, SimulationOutcome};
+use crate::filters::{FilterPipeline, SwapLogFilter};
+use crate::types::{AnalysisResult, Metrics, TransactionData};
+use crate::core::metrics::{simulate_sandwich_profit, U256Ext};
+use anyhow::{anyhow, Result};
+use ethers::abi::{AbiParser, Token};
+use ethers::utils::keccak256;
+use ethers::prelude::{Provider, Http, Middleware, TransactionRequest};
+use ethers::types::BlockId;
+use std::time::Duration;
+use ethernity_core::traits::RpcProvider;
+use std::sync::Arc;
+use ethereum_types::{Address, U256, H256};
+use async_trait::async_trait;
+
+pub struct UniswapV2Detector;
+
+#[async_trait]
+impl crate::detectors::VictimDetector for UniswapV2Detector {
+    fn supports(&self, router: &RouterInfo) -> bool {
+        router.factory.is_some()
+    }
+
+    async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        _outcome: SimulationOutcome,
+        _router: RouterInfo,
+    ) -> Result<AnalysisResult> {
+        analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block).await
+    }
+}
+
+pub async fn analyze_uniswap_v2(
+    rpc_client: Arc<dyn RpcProvider>,
+    rpc_endpoint: String,
+    tx: TransactionData,
+    block: Option<u64>,
+) -> Result<AnalysisResult> {
+    let sim_config = SimulationConfig {
+        rpc_endpoint,
+        block_number: block,
+    };
+
+    let outcome = simulate_transaction(&sim_config, &tx).await?;
+    let outcome = FilterPipeline::new()
+        .push(SwapLogFilter)
+        .run(outcome)
+        .ok_or(anyhow!("No swap event"))?;
+    let SimulationOutcome { tx_hash, logs } = outcome;
+
+    let router_address = crate::dex::router_from_logs(&logs)
+        .ok_or(anyhow!("router not found"))?;
+    let router: RouterInfo = crate::dex::identify_router(&*rpc_client, router_address).await?;
+
+    let (swap_kind, function) = detect_swap_function(&tx.data)
+        .ok_or(anyhow!("unrecognized swap"))?;
+    let tokens = function.decode_input(&tx.data[4..])?;
+
+    let (amount_in, amount_out, amount_in_max, amount_out_min, path) = match swap_kind {
+        SwapFunction::SwapExactTokensForTokens
+        | SwapFunction::SwapExactTokensForETH
+        | SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens
+        | SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens => {
+            let amount_in = tokens[0].clone().into_uint().unwrap();
+            let amount_out_min = tokens[1].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[2]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (Some(amount_in), None, None, Some(amount_out_min), path)
+        }
+        SwapFunction::SwapTokensForExactTokens | SwapFunction::SwapTokensForExactETH => {
+            let amount_out = tokens[0].clone().into_uint().unwrap();
+            let amount_in_max = tokens[1].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[2]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (None, Some(amount_out), Some(amount_in_max), None, path)
+        }
+        SwapFunction::SwapExactETHForTokens
+        | SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens => {
+            let amount_out_min = tokens[0].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[1]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (Some(tx.value), None, None, Some(amount_out_min), path)
+        }
+        SwapFunction::ETHForExactTokens => {
+            let amount_out = tokens[0].clone().into_uint().unwrap();
+            let path: Vec<Address> = tokens[1]
+                .clone()
+                .into_array()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.into_address().unwrap())
+                .collect();
+            (None, Some(amount_out), Some(tx.value), None, path)
+        }
+    };
+
+    let path_tokens: Vec<Token> = path.iter().map(|a| Token::Address(*a)).collect();
+
+    let provider = Provider::<Http>::try_from(sim_config.rpc_endpoint.clone())?
+        .interval(Duration::from_millis(1));
+
+    let (expected_out, expected_in) = if let Some(a_in) = amount_in {
+        let abi = AbiParser::default()
+            .parse_function("getAmountsOut(uint256,address[]) returns (uint256[])")?;
+        let data = abi.encode_input(&[Token::Uint(a_in), Token::Array(path_tokens.clone())])?;
+        let tx_call = TransactionRequest::new().to(router.address).data(data.clone());
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let out_tokens = abi.decode_output(&call)?;
+        let out = out_tokens[0].clone().into_array().unwrap().last().unwrap().clone().into_uint().unwrap();
+        (Some(out), None)
+    } else if let Some(a_out) = amount_out {
+        let abi = AbiParser::default()
+            .parse_function("getAmountsIn(uint256,address[]) returns (uint256[])")?;
+        let data = abi.encode_input(&[Token::Uint(a_out), Token::Array(path_tokens.clone())])?;
+        let tx_call = TransactionRequest::new().to(router.address).data(data.clone());
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let in_tokens = abi.decode_output(&call)?;
+        let inp = in_tokens[0].clone().into_array().unwrap().first().unwrap().clone().into_uint().unwrap();
+        (None, Some(inp))
+    } else {
+        (None, None)
+    };
+
+    let transfer_sig: H256 =
+        H256::from_slice(keccak256("Transfer(address,address,uint256)").as_slice());
+    let mut actual_out = U256::zero();
+    let mut actual_in = U256::zero();
+    for log in &logs {
+        if log.topics.get(0) == Some(&transfer_sig) && log.topics.len() == 3 {
+            let from_addr = Address::from_slice(&log.topics[1].as_bytes()[12..]);
+            let to_addr = Address::from_slice(&log.topics[2].as_bytes()[12..]);
+            if to_addr == tx.from {
+                actual_out = U256::from_big_endian(&log.data.0);
+            }
+            if from_addr == tx.from {
+                actual_in = U256::from_big_endian(&log.data.0);
+            }
+        }
+    }
+
+    let slippage = if let Some(exp_out) = expected_out {
+        if exp_out > actual_out {
+            (exp_out - actual_out).to_f64_lossy() / exp_out.to_f64_lossy()
+        } else {
+            0.0
+        }
+    } else if let Some(exp_in) = expected_in {
+        if actual_in > exp_in {
+            (actual_in - exp_in).to_f64_lossy() / exp_in.to_f64_lossy()
+        } else {
+            0.0
+        }
+    } else {
+        0.0
+    };
+
+    let pair_address = if let Some(factory) = router.factory {
+        get_pair_address(&*rpc_client, factory, path[0], path[1]).await?
+    } else {
+        return Err(anyhow!("router does not expose factory"));
+    };
+
+    let (reserve_in, reserve_out) = {
+        let abi = AbiParser::default()
+            .parse_function("getReserves() returns (uint112,uint112,uint32)")?;
+        let data = abi.encode_input(&[])?;
+        let tx_call = TransactionRequest::new().to(pair_address).data(data);
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let tokens = abi.decode_output(&call)?;
+        (
+            tokens[0].clone().into_uint().unwrap(),
+            tokens[1].clone().into_uint().unwrap(),
+        )
+    };
+    let min_tokens_to_affect = reserve_in / U256::from(100u64);
+    let input_for_profit = amount_in.unwrap_or(actual_in);
+    let potential_profit = simulate_sandwich_profit(input_for_profit, reserve_in, reserve_out);
+
+    let metrics = Metrics {
+        swap_function: swap_kind,
+        token_route: path.clone(),
+        slippage,
+        min_tokens_to_affect,
+        potential_profit,
+        router_address: router.address,
+        router_name: router.name.clone(),
+    };
+
+    let potential_victim = if let Some(out_min) = amount_out_min {
+        slippage > 0.0 && expected_out.unwrap_or(U256::zero()) >= out_min
+    } else if let Some(in_max) = amount_in_max {
+        slippage > 0.0 && actual_in <= in_max
+    } else {
+        slippage > 0.0
+    };
+
+    Ok(AnalysisResult {
+        potential_victim,
+        economically_viable: potential_profit > U256::zero(),
+        simulated_tx: tx_hash,
+        metrics,
+    })
+}
+

--- a/crates/sandwich-victim/src/dex/query.rs
+++ b/crates/sandwich-victim/src/dex/query.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 /// Consulta as reservas de um par Uniswap V2-like
 pub async fn get_pair_reserves<P>(provider: &P, pair: Address) -> Result<(U256, U256)>
 where
-    P: RpcProvider + Sync,
+    P: RpcProvider + Sync + ?Sized,
 {
     let abi = AbiParser::default()
         .parse_function("getReserves() returns (uint112,uint112,uint32)")?;
@@ -28,7 +28,7 @@ pub async fn get_pair_address<P>(
     token_b: Address,
 ) -> Result<Address>
 where
-    P: RpcProvider + Sync,
+    P: RpcProvider + Sync + ?Sized,
 {
     let abi = AbiParser::default()
         .parse_function("getPair(address,address) view returns (address)")?;

--- a/crates/sandwich-victim/src/dex/router.rs
+++ b/crates/sandwich-victim/src/dex/router.rs
@@ -17,7 +17,7 @@ pub struct RouterInfo {
 /// Identifica dinamicamente o router utilizado na transação
 pub async fn identify_router<P>(provider: &P, addr: Address) -> Result<RouterInfo>
 where
-    P: RpcProvider + Sync,
+    P: RpcProvider + Sync + ?Sized,
 {
     // identificação genérica sem dependência de constantes "chumbadas"
     let name = None;

--- a/crates/sandwich-victim/src/lib.rs
+++ b/crates/sandwich-victim/src/lib.rs
@@ -9,3 +9,4 @@ pub mod simulation;
 pub mod dex;
 pub mod core;
 pub mod filters;
+pub mod detectors;


### PR DESCRIPTION
## Summary
- refactor sandwich-victim crate to use a `DetectorRegistry`
- implement UniswapV2Detector module and move previous logic
- expose new `detectors` module
- update analyzer to dispatch to detectors
- allow RPC traits to be used as trait objects

## Testing
- `cargo check -p sandwich-victim`
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6862b17f6c008332a03f3f2304213222