### PR TITLE
Add PancakeSwap router v3 multicall detector

### DIFF
--- a/crates/sandwich-victim/README.md
+++ b/crates/sandwich-victim/README.md
@@ -8,6 +8,7 @@ Biblioteca para detectar oportunidades de ataque *sandwich* em transações Ethe
 - lucro potencial de uma estratégia de front‑run e back‑run
 - identificação dinâmica do router envolvido (extraído exclusivamente dos logs da simulação)
 - reconhecimento de todas as variações de funções de swap V2
+- suporte ao PancakeSwap SmartRouterV3 com decodificação da multicall
 
 A arquitetura segue o princípio de responsabilidade única. Cada módulo possui
 uma função clara:

--- a/crates/sandwich-victim/src/detectors/mod.rs
+++ b/crates/sandwich-victim/src/detectors/mod.rs
@@ -1,13 +1,15 @@
-use async_trait::async_trait;
-use crate::types::{AnalysisResult, TransactionData};
-use crate::simulation::SimulationOutcome;
 use crate::dex::RouterInfo;
+use crate::simulation::SimulationOutcome;
+use crate::types::{AnalysisResult, TransactionData};
+use anyhow::Result;
+use async_trait::async_trait;
 use ethernity_core::traits::RpcProvider;
 use std::sync::Arc;
-use anyhow::Result;
 
 pub mod uniswap_v2;
 use uniswap_v2::UniswapV2Detector;
+pub mod pancakeswap_v3;
+use pancakeswap_v3::PancakeSwapV3Detector;
 
 #[async_trait]
 pub trait VictimDetector: Send + Sync {
@@ -29,7 +31,9 @@ pub struct DetectorRegistry {
 
 impl Default for DetectorRegistry {
     fn default() -> Self {
-        Self { detectors: vec![Box::new(UniswapV2Detector)] }
+        Self {
+            detectors: vec![Box::new(PancakeSwapV3Detector), Box::new(UniswapV2Detector)],
+        }
     }
 }
 
@@ -46,11 +50,17 @@ impl DetectorRegistry {
         for d in &self.detectors {
             if d.supports(&router) {
                 return d
-                    .analyze(rpc_client.clone(), rpc_endpoint.clone(), tx.clone(), block, outcome.clone(), router.clone())
+                    .analyze(
+                        rpc_client.clone(),
+                        rpc_endpoint.clone(),
+                        tx.clone(),
+                        block,
+                        outcome.clone(),
+                        router.clone(),
+                    )
                     .await;
             }
         }
         Err(anyhow::anyhow!("unsupported router"))
     }
 }
-

--- a/crates/sandwich-victim/src/detectors/pancakeswap_v3.rs
+++ b/crates/sandwich-victim/src/detectors/pancakeswap_v3.rs
@@ -1,0 +1,62 @@
+use crate::detectors::uniswap_v2::analyze_uniswap_v2;
+use crate::dex::{detect_swap_function, RouterInfo};
+use crate::simulation::SimulationOutcome;
+use crate::types::{AnalysisResult, TransactionData};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use ethernity_core::traits::RpcProvider;
+use ethers::abi::AbiParser;
+use std::sync::Arc;
+
+pub struct PancakeSwapV3Detector;
+
+#[async_trait]
+impl crate::detectors::VictimDetector for PancakeSwapV3Detector {
+    fn supports(&self, _router: &RouterInfo) -> bool {
+        true
+    }
+
+    async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        _outcome: SimulationOutcome,
+        _router: RouterInfo,
+    ) -> Result<AnalysisResult> {
+        analyze_pancakeswap_v3(rpc_client, rpc_endpoint, tx, block).await
+    }
+}
+
+pub async fn analyze_pancakeswap_v3(
+    rpc_client: Arc<dyn RpcProvider>,
+    rpc_endpoint: String,
+    tx: TransactionData,
+    block: Option<u64>,
+) -> Result<AnalysisResult> {
+    const MULTICALL_SELECTOR: [u8; 4] = [0x5a, 0xe4, 0x01, 0xdc];
+    if tx.data.len() < 4 || tx.data[..4] != MULTICALL_SELECTOR {
+        return Err(anyhow!("not a multicall"));
+    }
+
+    let abi = AbiParser::default().parse_function("multicall(uint256,bytes[])")?;
+    let tokens = abi.decode_input(&tx.data[4..])?;
+    let calls: Vec<Vec<u8>> = tokens[1]
+        .clone()
+        .into_array()
+        .unwrap()
+        .into_iter()
+        .map(|t| t.into_bytes().unwrap())
+        .collect();
+
+    for call in calls {
+        if detect_swap_function(&call).is_some() {
+            let mut inner = tx.clone();
+            inner.data = call;
+            return analyze_uniswap_v2(rpc_client, rpc_endpoint, inner, block).await;
+        }
+    }
+
+    Err(anyhow!("no swap call found"))
+}

--- a/crates/sandwich-victim/src/dex/decoder.rs
+++ b/crates/sandwich-victim/src/dex/decoder.rs
@@ -13,6 +13,10 @@ pub enum SwapFunction {
     SwapExactTokensForTokensSupportingFeeOnTransferTokens,
     SwapExactETHForTokensSupportingFeeOnTransferTokens,
     SwapExactTokensForETHSupportingFeeOnTransferTokens,
+    ExactInputSingle,
+    ExactInput,
+    ExactOutputSingle,
+    ExactOutput,
 }
 
 impl SwapFunction {
@@ -45,6 +49,18 @@ impl SwapFunction {
             SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens => {
                 "swapExactTokensForETHSupportingFeeOnTransferTokens(uint256,uint256,address[],address,uint256)"
             }
+            SwapFunction::ExactInputSingle => {
+                "exactInputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160))"
+            }
+            SwapFunction::ExactInput => {
+                "exactInput((bytes,address,uint256,uint256,uint256))"
+            }
+            SwapFunction::ExactOutputSingle => {
+                "exactOutputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160))"
+            }
+            SwapFunction::ExactOutput => {
+                "exactOutput((bytes,address,uint256,uint256,uint256))"
+            }
         }
     }
 }
@@ -66,6 +82,10 @@ pub fn detect_swap_function(data: &[u8]) -> Option<(SwapFunction, Function)> {
         SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens,
         SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens,
         SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens,
+        SwapFunction::ExactInputSingle,
+        SwapFunction::ExactInput,
+        SwapFunction::ExactOutputSingle,
+        SwapFunction::ExactOutput,
     ] {
         let f = parser.parse_function(func.signature()).expect("abi parse");
         if selector == f.short_signature() {


### PR DESCRIPTION
## Summary
- detect PancakeSwap SmartRouterV3 multicall swaps
- handle new Uniswap V3 style swap functions
- register the new detector
- add README note about multicall support

## Testing
- `cargo test -p sandwich-victim`

------
https://chatgpt.com/codex/tasks/task_e_6862ba64737c8332b39a639709dbe87a