### PR TITLE
Add multicall(bytes[]) detector

### DIFF
--- a/crates/sandwich-victim/src/detectors/mod.rs
+++ b/crates/sandwich-victim/src/detectors/mod.rs
@@ -10,6 +10,8 @@ pub mod uniswap_v2;
 use uniswap_v2::UniswapV2Detector;
 pub mod pancakeswap_v3;
 use pancakeswap_v3::PancakeSwapV3Detector;
+pub mod multicall_bytes;
+use multicall_bytes::MulticallBytesDetector;
 pub mod swap_v2_exact_in;
 use swap_v2_exact_in::SwapV2ExactInDetector;
 
@@ -36,6 +38,7 @@ impl Default for DetectorRegistry {
         Self {
             detectors: vec![
                 Box::new(PancakeSwapV3Detector),
+                Box::new(MulticallBytesDetector),
                 Box::new(UniswapV2Detector),
                 Box::new(SwapV2ExactInDetector),
             ],
@@ -79,4 +82,3 @@ impl DetectorRegistry {
         }
     }
 }
-

--- a/crates/sandwich-victim/src/detectors/multicall_bytes.rs
+++ b/crates/sandwich-victim/src/detectors/multicall_bytes.rs
@@ -60,11 +60,13 @@ pub async fn analyze_multicall_bytes(
         if detect_swap_function(&call).is_some() {
             let mut inner = tx.clone();
             inner.data = call.clone();
+            inner.to = router.address;
             let res = analyze_uniswap_v2(
                 rpc_client.clone(),
                 rpc_endpoint.clone(),
                 inner,
                 block,
+                router.clone(),
             )
             .await;
             match res {

--- a/crates/sandwich-victim/src/detectors/multicall_bytes.rs
+++ b/crates/sandwich-victim/src/detectors/multicall_bytes.rs
@@ -1,0 +1,63 @@
+use crate::detectors::uniswap_v2::analyze_uniswap_v2;
+use crate::dex::{detect_swap_function, RouterInfo};
+use crate::simulation::SimulationOutcome;
+use crate::types::{AnalysisResult, TransactionData};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use ethernity_core::traits::RpcProvider;
+use ethers::abi::AbiParser;
+use std::sync::Arc;
+
+/// Detector para a função `multicall(bytes[])`.
+pub struct MulticallBytesDetector;
+
+#[async_trait]
+impl crate::detectors::VictimDetector for MulticallBytesDetector {
+    fn supports(&self, _router: &RouterInfo) -> bool {
+        true
+    }
+
+    async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        _outcome: SimulationOutcome,
+        _router: RouterInfo,
+    ) -> Result<AnalysisResult> {
+        analyze_multicall_bytes(rpc_client, rpc_endpoint, tx, block).await
+    }
+}
+
+pub async fn analyze_multicall_bytes(
+    rpc_client: Arc<dyn RpcProvider>,
+    rpc_endpoint: String,
+    tx: TransactionData,
+    block: Option<u64>,
+) -> Result<AnalysisResult> {
+    const MULTICALL_SELECTOR: [u8; 4] = [0xac, 0x96, 0x50, 0xd8];
+    if tx.data.len() < 4 || tx.data[..4] != MULTICALL_SELECTOR {
+        return Err(anyhow!("not a multicall"));
+    }
+
+    let abi = AbiParser::default().parse_function("multicall(bytes[])")?;
+    let tokens = abi.decode_input(&tx.data[4..])?;
+    let calls: Vec<Vec<u8>> = tokens[0]
+        .clone()
+        .into_array()
+        .unwrap()
+        .into_iter()
+        .map(|t| t.into_bytes().unwrap())
+        .collect();
+
+    for call in calls {
+        if detect_swap_function(&call).is_some() {
+            let mut inner = tx.clone();
+            inner.data = call;
+            return analyze_uniswap_v2(rpc_client, rpc_endpoint, inner, block).await;
+        }
+    }
+
+    Err(anyhow!("no swap call found"))
+}

--- a/crates/sandwich-victim/src/detectors/pancakeswap_v3.rs
+++ b/crates/sandwich-victim/src/detectors/pancakeswap_v3.rs
@@ -23,9 +23,9 @@ impl crate::detectors::VictimDetector for PancakeSwapV3Detector {
         tx: TransactionData,
         block: Option<u64>,
         _outcome: SimulationOutcome,
-        _router: RouterInfo,
+        router: RouterInfo,
     ) -> Result<AnalysisResult> {
-        analyze_pancakeswap_v3(rpc_client, rpc_endpoint, tx, block).await
+        analyze_pancakeswap_v3(rpc_client, rpc_endpoint, tx, block, router).await
     }
 }
 
@@ -34,6 +34,7 @@ pub async fn analyze_pancakeswap_v3(
     rpc_endpoint: String,
     tx: TransactionData,
     block: Option<u64>,
+    router: RouterInfo,
 ) -> Result<AnalysisResult> {
     const MULTICALL_SELECTOR: [u8; 4] = [0x5a, 0xe4, 0x01, 0xdc];
     if tx.data.len() < 4 || tx.data[..4] != MULTICALL_SELECTOR {
@@ -54,7 +55,8 @@ pub async fn analyze_pancakeswap_v3(
         if detect_swap_function(&call).is_some() {
             let mut inner = tx.clone();
             inner.data = call;
-            return analyze_uniswap_v2(rpc_client, rpc_endpoint, inner, block).await;
+            inner.to = router.address;
+            return analyze_uniswap_v2(rpc_client, rpc_endpoint, inner, block, router.clone()).await;
         }
     }
 

--- a/crates/sandwich-victim/src/detectors/swap_v2_exact_in.rs
+++ b/crates/sandwich-victim/src/detectors/swap_v2_exact_in.rs
@@ -22,14 +22,14 @@ impl crate::detectors::VictimDetector for SwapV2ExactInDetector {
         tx: TransactionData,
         block: Option<u64>,
         _outcome: SimulationOutcome,
-        _router: RouterInfo,
+        router: RouterInfo,
     ) -> Result<AnalysisResult> {
         let (kind, _) = detect_swap_function(&tx.data).ok_or(anyhow!("unrecognized swap"))?;
         if kind != SwapFunction::SwapV2ExactIn {
             return Err(anyhow!("unsupported swap"));
         }
 
-        analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block).await
+        analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block, router).await
     }
 }
 

--- a/crates/sandwich-victim/src/detectors/uniswap_v2.rs
+++ b/crates/sandwich-victim/src/detectors/uniswap_v2.rs
@@ -29,9 +29,9 @@ impl crate::detectors::VictimDetector for UniswapV2Detector {
         tx: TransactionData,
         block: Option<u64>,
         _outcome: SimulationOutcome,
-        _router: RouterInfo,
+        router: RouterInfo,
     ) -> Result<AnalysisResult> {
-        analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block).await
+        analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block, router).await
     }
 }
 
@@ -40,6 +40,7 @@ pub async fn analyze_uniswap_v2(
     rpc_endpoint: String,
     tx: TransactionData,
     block: Option<u64>,
+    router: RouterInfo,
 ) -> Result<AnalysisResult> {
     let sim_config = SimulationConfig {
         rpc_endpoint,
@@ -53,8 +54,13 @@ pub async fn analyze_uniswap_v2(
         .ok_or(anyhow!("No swap event"))?;
     let SimulationOutcome { tx_hash, logs } = outcome;
 
-    let router_address = crate::dex::router_from_logs(&logs).ok_or(anyhow!("router not found"))?;
-    let router: RouterInfo = crate::dex::identify_router(&*rpc_client, router_address).await?;
+    // Use provided router information when available
+    let router_address = crate::dex::router_from_logs(&logs).unwrap_or(router.address);
+    let router: RouterInfo = if router_address == router.address {
+        router.clone()
+    } else {
+        crate::dex::identify_router(&*rpc_client, router_address).await?
+    };
 
     use std::collections::HashSet;
 


### PR DESCRIPTION
## Summary
- support multicall(bytes[]) variant for sandwich-victim
- register the new detector

## Testing
- `cargo test -p sandwich-victim`

------
https://chatgpt.com/codex/tasks/task_e_6863225ade7c8332865fcd2aff5466be