### PR TITLE
Add 1inch Generic Router detector

### DIFF
--- a/crates/sandwich-victim/src/detectors/clusters/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/mod.rs
@@ -2,6 +2,7 @@ pub mod uniswap_v2;
 pub mod uniswap_v3;
 pub mod uniswap_v4;
 pub mod smart_router;
+pub mod oneinch_generic_router;
 
 /// Agrupamento semântico das implementações de detectores.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sandwich-victim/src/detectors/clusters/oneinch_generic_router/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/oneinch_generic_router/mod.rs
@@ -1,0 +1,48 @@
+use crate::detectors::clusters::uniswap_v2::analyze_uniswap_v2;
+use crate::dex::RouterInfo;
+use crate::simulation::SimulationOutcome;
+use crate::types::{AnalysisResult, TransactionData};
+use anyhow::Result;
+use async_trait::async_trait;
+use ethereum_types::Address;
+use ethernity_core::traits::RpcProvider;
+use once_cell::sync::Lazy;
+use std::str::FromStr;
+use std::sync::Arc;
+
+/// Detector para o Generic Router da 1inch.
+pub struct OneInchGenericRouterDetector;
+
+static GENERIC_ROUTER_ADDRESS: Lazy<Address> = Lazy::new(|| {
+    Address::from_str("0x1111111254eeb25477b68fb85ed929f73a960582").expect("valid address")
+});
+
+#[async_trait]
+impl crate::detectors::VictimDetector for OneInchGenericRouterDetector {
+    fn supports(&self, router: &RouterInfo) -> bool {
+        router.address == *GENERIC_ROUTER_ADDRESS
+    }
+
+    async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        outcome: SimulationOutcome,
+        router: RouterInfo,
+    ) -> Result<AnalysisResult> {
+        analyze_oneinch_generic_router(rpc_client, rpc_endpoint, tx, block, outcome, router).await
+    }
+}
+
+pub async fn analyze_oneinch_generic_router(
+    rpc_client: Arc<dyn RpcProvider>,
+    rpc_endpoint: String,
+    tx: TransactionData,
+    block: Option<u64>,
+    _outcome: SimulationOutcome,
+    router: RouterInfo,
+) -> Result<AnalysisResult> {
+    analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block, router).await
+}

--- a/crates/sandwich-victim/src/detectors/clusters/oneinch_generic_router/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/oneinch_generic_router/mod.rs
@@ -1,4 +1,4 @@
-use crate::detectors::clusters::uniswap_v2::analyze_uniswap_v2;
+use crate::detectors::clusters::uniswap_v2::analyze_uniswap_v2_with_outcome;
 use crate::dex::RouterInfo;
 use crate::simulation::SimulationOutcome;
 use crate::types::{AnalysisResult, TransactionData};
@@ -41,8 +41,8 @@ pub async fn analyze_oneinch_generic_router(
     rpc_endpoint: String,
     tx: TransactionData,
     block: Option<u64>,
-    _outcome: SimulationOutcome,
+    outcome: SimulationOutcome,
     router: RouterInfo,
 ) -> Result<AnalysisResult> {
-    analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block, router).await
+    analyze_uniswap_v2_with_outcome(rpc_client, rpc_endpoint, tx, block, outcome, router).await
 }

--- a/crates/sandwich-victim/src/detectors/clusters/uniswap_v2/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/uniswap_v2/mod.rs
@@ -31,10 +31,18 @@ impl crate::detectors::VictimDetector for UniswapV2Detector {
         rpc_endpoint: String,
         tx: TransactionData,
         block: Option<u64>,
-        _outcome: SimulationOutcome,
+        outcome: SimulationOutcome,
         router: RouterInfo,
     ) -> Result<AnalysisResult> {
-        analyze_uniswap_v2(rpc_client, rpc_endpoint, tx, block, router).await
+        analyze_uniswap_v2_with_outcome(
+            rpc_client,
+            rpc_endpoint,
+            tx,
+            block,
+            outcome,
+            router,
+        )
+        .await
     }
 }
 
@@ -176,6 +184,323 @@ pub async fn analyze_uniswap_v2(
     let path_tokens: Vec<Token> = path.iter().map(|a| Token::Address(*a)).collect();
 
     let provider = Provider::<Http>::try_from(sim_config.rpc_endpoint.clone())?
+        .interval(Duration::from_millis(1));
+
+    let pair_address = if let Some(addr) = pair_addr_opt {
+        addr
+    } else if let Some(factory) = router.factory {
+        get_pair_address(&*rpc_client, factory, path[0], path[1]).await?
+    } else {
+        return Err(anyhow!("router does not expose factory"));
+    };
+
+    let (token0, token1, reserve0, reserve1) = {
+        let abi = AbiParser::default().parse_function("token0() view returns (address)")?;
+        let data = abi.encode_input(&[])?;
+        let tx_call = TransactionRequest::new()
+            .to(pair_address)
+            .data(data.clone());
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let token0 = abi.decode_output(&call)?[0].clone().into_address().unwrap();
+
+        let abi1 = AbiParser::default().parse_function("token1() view returns (address)")?;
+        let data1 = abi1.encode_input(&[])?;
+        let tx_call = TransactionRequest::new()
+            .to(pair_address)
+            .data(data1.clone());
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let token1 = abi1.decode_output(&call)?[0]
+            .clone()
+            .into_address()
+            .unwrap();
+
+        let abi_res = AbiParser::default()
+            .parse_function("getReserves() returns (uint112,uint112,uint32)")?;
+        let data_res = abi_res.encode_input(&[])?;
+        let tx_call = TransactionRequest::new().to(pair_address).data(data_res);
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let tokens = abi_res.decode_output(&call)?;
+        (
+            token0,
+            token1,
+            tokens[0].clone().into_uint().unwrap(),
+            tokens[1].clone().into_uint().unwrap(),
+        )
+    };
+
+    let (reserve_in, reserve_out) = if token0 == path[1] {
+        (reserve1, reserve0)
+    } else {
+        (reserve0, reserve1)
+    };
+
+    let (expected_out, expected_in) = if let Some(a_in) = amount_in {
+        if pair_addr_opt.is_some() {
+            (
+                Some(constant_product_output(a_in, reserve_in, reserve_out)),
+                None,
+            )
+        } else {
+            let abi = AbiParser::default()
+                .parse_function("getAmountsOut(uint256,address[]) returns (uint256[])")?;
+            let data = abi.encode_input(&[Token::Uint(a_in), Token::Array(path_tokens.clone())])?;
+            let tx_call = TransactionRequest::new()
+                .to(router.address)
+                .data(data.clone());
+            let call = provider
+                .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+                .await
+                .map_err(|e| anyhow!(e))?;
+            let out_tokens = abi.decode_output(&call)?;
+            let out = out_tokens[0]
+                .clone()
+                .into_array()
+                .unwrap()
+                .last()
+                .unwrap()
+                .clone()
+                .into_uint()
+                .unwrap();
+            (Some(out), None)
+        }
+    } else if let Some(a_out) = amount_out {
+        let abi = AbiParser::default()
+            .parse_function("getAmountsIn(uint256,address[]) returns (uint256[])")?;
+        let data = abi.encode_input(&[Token::Uint(a_out), Token::Array(path_tokens.clone())])?;
+        let tx_call = TransactionRequest::new()
+            .to(router.address)
+            .data(data.clone());
+        let call = provider
+            .call(&tx_call.into(), block.map(|b| BlockId::Number(b.into())))
+            .await
+            .map_err(|e| anyhow!(e))?;
+        let in_tokens = abi.decode_output(&call)?;
+        let inp = in_tokens[0]
+            .clone()
+            .into_array()
+            .unwrap()
+            .first()
+            .unwrap()
+            .clone()
+            .into_uint()
+            .unwrap();
+        (None, Some(inp))
+    } else {
+        (None, None)
+    };
+
+    let transfer_sig: H256 =
+        H256::from_slice(keccak256("Transfer(address,address,uint256)").as_slice());
+    let mut actual_out = U256::zero();
+    let mut actual_in = U256::zero();
+    for log in &logs {
+        if log.topics.get(0) == Some(&transfer_sig) && log.topics.len() == 3 {
+            let from_addr = Address::from_slice(&log.topics[1].as_bytes()[12..]);
+            let to_addr = Address::from_slice(&log.topics[2].as_bytes()[12..]);
+            if to_addr == tx.from {
+                actual_out = U256::from_big_endian(&log.data.0);
+            }
+            if from_addr == tx.from {
+                actual_in = U256::from_big_endian(&log.data.0);
+            }
+        }
+    }
+
+    let slippage = if let Some(exp_out) = expected_out {
+        if exp_out > actual_out {
+            (exp_out - actual_out).to_f64_lossy() / exp_out.to_f64_lossy()
+        } else {
+            0.0
+        }
+    } else if let Some(exp_in) = expected_in {
+        if actual_in > exp_in {
+            (actual_in - exp_in).to_f64_lossy() / exp_in.to_f64_lossy()
+        } else {
+            0.0
+        }
+    } else {
+        0.0
+    };
+
+    let min_tokens_to_affect = reserve_in / U256::from(100u64);
+    let input_for_profit = amount_in.unwrap_or(actual_in);
+    let potential_profit = simulate_sandwich_profit(input_for_profit, reserve_in, reserve_out);
+
+    let router_name = router
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("{:#x}", router.address));
+
+    let metrics = Metrics {
+        swap_function: swap_kind,
+        token_route: path.clone(),
+        slippage,
+        min_tokens_to_affect,
+        potential_profit,
+        router_address: router.address,
+        router_name: Some(router_name),
+    };
+
+    let potential_victim = if let Some(out_min) = amount_out_min {
+        slippage > 0.0 && expected_out.unwrap_or(U256::zero()) >= out_min
+    } else if let Some(in_max) = amount_in_max {
+        slippage > 0.0 && actual_in <= in_max
+    } else {
+        slippage > 0.0
+    };
+
+    Ok(AnalysisResult {
+        potential_victim,
+        economically_viable: potential_profit > U256::zero(),
+        simulated_tx: tx_hash,
+        metrics,
+    })
+}
+
+/// Same analysis logic as [`analyze_uniswap_v2`] but uses a precomputed
+/// [`SimulationOutcome`] instead of performing a new simulation.
+pub async fn analyze_uniswap_v2_with_outcome(
+    rpc_client: Arc<dyn RpcProvider>,
+    rpc_endpoint: String,
+    tx: TransactionData,
+    block: Option<u64>,
+    outcome: SimulationOutcome,
+    router: RouterInfo,
+) -> Result<AnalysisResult> {
+    let outcome = FilterPipeline::new()
+        .push(SwapLogFilter)
+        .run(outcome)
+        .ok_or(anyhow!("No swap event"))?;
+    let SimulationOutcome { tx_hash, logs } = outcome;
+
+    // Use provided router information when available
+    let router_address = crate::dex::router_from_logs(&logs).unwrap_or(router.address);
+    let router: RouterInfo = if router_address == router.address {
+        router.clone()
+    } else {
+        crate::dex::identify_router(&*rpc_client, router_address).await?
+    };
+
+    use std::collections::HashSet;
+
+    let deposit_topic: H256 = H256::from_slice(keccak256("Deposit(address,uint256)").as_slice());
+    let deposit_tokens: HashSet<Address> = logs
+        .iter()
+        .filter(|log| log.topics.get(0) == Some(&deposit_topic))
+        .map(|log| log.address)
+        .collect();
+    let deposit_token = if deposit_tokens.len() == 1 {
+        deposit_tokens.iter().next().copied()
+    } else {
+        None
+    };
+
+    let (swap_kind, function) =
+        detect_swap_function(&tx.data).ok_or(anyhow!("unrecognized swap"))?;
+    let tokens = function.decode_input(&tx.data[4..])?;
+
+    let (amount_in, amount_out, amount_in_max, amount_out_min, path, pair_addr_opt) =
+        match swap_kind {
+            SwapFunction::SwapExactTokensForTokens
+            | SwapFunction::SwapExactTokensForETH
+            | SwapFunction::SwapExactTokensForTokensSupportingFeeOnTransferTokens
+            | SwapFunction::SwapExactTokensForETHSupportingFeeOnTransferTokens => {
+                let amount_in = tokens[0].clone().into_uint().unwrap();
+                let amount_out_min = tokens[1].clone().into_uint().unwrap();
+                let path: Vec<Address> = tokens[2]
+                    .clone()
+                    .into_array()
+                    .unwrap()
+                    .into_iter()
+                    .map(|t| t.into_address().unwrap())
+                    .collect();
+                (
+                    Some(amount_in),
+                    None,
+                    None,
+                    Some(amount_out_min),
+                    path,
+                    None,
+                )
+            }
+            SwapFunction::SwapTokensForExactTokens | SwapFunction::SwapTokensForExactETH => {
+                let amount_out = tokens[0].clone().into_uint().unwrap();
+                let amount_in_max = tokens[1].clone().into_uint().unwrap();
+                let path: Vec<Address> = tokens[2]
+                    .clone()
+                    .into_array()
+                    .unwrap()
+                    .into_iter()
+                    .map(|t| t.into_address().unwrap())
+                    .collect();
+                (
+                    None,
+                    Some(amount_out),
+                    Some(amount_in_max),
+                    None,
+                    path,
+                    None,
+                )
+            }
+            SwapFunction::SwapExactETHForTokens
+            | SwapFunction::SwapExactETHForTokensSupportingFeeOnTransferTokens => {
+                let amount_out_min = tokens[0].clone().into_uint().unwrap();
+                let path: Vec<Address> = tokens[1]
+                    .clone()
+                    .into_array()
+                    .unwrap()
+                    .into_iter()
+                    .map(|t| t.into_address().unwrap())
+                    .collect();
+                (Some(tx.value), None, None, Some(amount_out_min), path, None)
+            }
+            SwapFunction::ETHForExactTokens => {
+                let amount_out = tokens[0].clone().into_uint().unwrap();
+                let path: Vec<Address> = tokens[1]
+                    .clone()
+                    .into_array()
+                    .unwrap()
+                    .into_iter()
+                    .map(|t| t.into_address().unwrap())
+                    .collect();
+                (None, Some(amount_out), Some(tx.value), None, path, None)
+            }
+            SwapFunction::SwapV2ExactIn => {
+                let mut token_in = tokens[0].clone().into_address().unwrap();
+                if token_in == Address::zero() {
+                    if let Some(deposit) = deposit_token {
+                        token_in = deposit;
+                    }
+                }
+                let token_out = tokens[1].clone().into_address().unwrap();
+                let amount_in = tokens[2].clone().into_uint().unwrap();
+                let amount_out_min = tokens[3].clone().into_uint().unwrap();
+                let pair = tokens[4].clone().into_address().unwrap();
+                let path = vec![token_in, token_out];
+                (
+                    Some(amount_in),
+                    None,
+                    None,
+                    Some(amount_out_min),
+                    path,
+                    Some(pair),
+                )
+            }
+            _ => return Err(anyhow!("unsupported swap")),
+        };
+
+    let path_tokens: Vec<Token> = path.iter().map(|a| Token::Address(*a)).collect();
+
+    let provider = Provider::<Http>::try_from(rpc_endpoint.clone())?
         .interval(Duration::from_millis(1));
 
     let pair_address = if let Some(addr) = pair_addr_opt {

--- a/crates/sandwich-victim/src/detectors/mod.rs
+++ b/crates/sandwich-victim/src/detectors/mod.rs
@@ -12,6 +12,7 @@ use clusters::uniswap_v3::UniswapV3Detector;
 use clusters::uniswap_v4::UniswapV4Detector;
 use clusters::smart_router::MulticallBytesDetector;
 use clusters::smart_router::custom::SmartRouterUniswapV3Detector;
+use clusters::oneinch_generic_router::OneInchGenericRouterDetector;
 
 #[async_trait]
 pub trait VictimDetector: Send + Sync {
@@ -38,6 +39,7 @@ impl Default for DetectorRegistry {
                 Box::new(UniswapV3Detector),
                 Box::new(SmartRouterUniswapV3Detector),
                 Box::new(MulticallBytesDetector),
+                Box::new(OneInchGenericRouterDetector),
                 Box::new(UniswapV4Detector),
                 Box::new(UniswapV2Detector),
                 Box::new(SwapV2ExactInDetector),


### PR DESCRIPTION
## Summary
- detect swaps executed via 1inch Generic Router
- expose new cluster module and register the detector

## Testing
- `cargo test -p sandwich-victim --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68642abecc98833291d09f616df3430f