### PR TITLE
Add semantic log mapping to simulation

### DIFF
--- a/crates/sandwich-victim/src/lib.rs
+++ b/crates/sandwich-victim/src/lib.rs
@@ -9,4 +9,5 @@ pub mod simulation;
 pub mod dex;
 pub mod core;
 pub mod filters;
+pub mod log_semantics;
 pub mod detectors;

--- a/crates/sandwich-victim/src/log_semantics.rs
+++ b/crates/sandwich-victim/src/log_semantics.rs
@@ -1,0 +1,58 @@
+use ethers::abi::{AbiParser, Event, RawLog, Token, EventExt};
+use ethers::types::{Address, Log, H256};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use ethers::utils::keccak256;
+
+#[derive(Debug, Clone)]
+pub struct MappedLog {
+    pub address: Address,
+    pub event: String,
+    pub params: Vec<(String, Token)>,
+}
+
+fn build_event_map() -> HashMap<H256, Event> {
+    let mut map = HashMap::new();
+    let mut parser = AbiParser::default();
+    // Uniswap V3 Swap event
+    if let Ok(ev) = parser.parse_event("event Swap(address indexed sender,address indexed recipient,int256 amount0,int256 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint128 protocolFeesToken0,uint128 protocolFeesToken1)") {
+        let topic = H256::from_slice(keccak256(ev.abi_signature()).as_slice());
+        map.insert(topic, ev);
+    }
+    // Uniswap V2 Swap event
+    if let Ok(ev) = parser.parse_event("event Swap(address indexed sender,uint256 amount0In,uint256 amount1In,uint256 amount0Out,uint256 amount1Out,address indexed to)") {
+        let topic = H256::from_slice(keccak256(ev.abi_signature()).as_slice());
+        map.insert(topic, ev);
+    }
+    map
+}
+
+static EVENT_MAP: Lazy<HashMap<H256, Event>> = Lazy::new(build_event_map);
+
+/// Decodes logs using known event signatures
+pub fn map_logs(logs: &[Log]) -> Vec<MappedLog> {
+    logs
+        .iter()
+        .filter_map(|log| {
+            let topic0 = log.topics.get(0)?;
+            let event = EVENT_MAP.get(topic0)?;
+            let raw = RawLog {
+                topics: log.topics.clone(),
+                data: log.data.to_vec(),
+            };
+            match event.parse_log(raw) {
+                Ok(decoded) => Some(MappedLog {
+                    address: log.address,
+                    event: event.name.clone(),
+                    params: decoded
+                        .params
+                        .into_iter()
+                        .map(|p| (p.name, p.value))
+                        .collect(),
+                }),
+                Err(_) => None,
+            }
+        })
+        .collect()
+}
+

--- a/crates/sandwich-victim/src/simulation/executor.rs
+++ b/crates/sandwich-victim/src/simulation/executor.rs
@@ -17,6 +17,13 @@ pub struct SimulationOutcome {
     pub logs: Vec<Log>,
 }
 
+impl SimulationOutcome {
+    /// Retorna os logs decodificados de acordo com os mapeamentos semânticos
+    pub fn decoded_logs(&self) -> Vec<crate::log_semantics::MappedLog> {
+        crate::log_semantics::map_logs(&self.logs)
+    }
+}
+
 /// Executa a transação em um fork local utilizando o Anvil
 pub async fn simulate_transaction(
     config: &SimulationConfig,

--- a/crates/sandwich-victim/tests/log_semantics_test.rs
+++ b/crates/sandwich-victim/tests/log_semantics_test.rs
@@ -1,0 +1,32 @@
+use sandwich_victim::log_semantics::map_logs;
+use ethers::abi::{AbiParser, Token, EventExt, encode};
+use ethers::types::{Address, Log, Bytes, H256};
+use ethers::utils::keccak256;
+
+#[test]
+fn decode_uniswap_v3_swap() {
+    let mut parser = AbiParser::default();
+    let event = parser.parse_event("event Swap(address indexed sender,address indexed recipient,int256 amount0,int256 amount1,uint160 sqrtPriceX96,uint128 liquidity,int24 tick,uint128 protocolFeesToken0,uint128 protocolFeesToken1)").unwrap();
+    let topic0 = H256::from_slice(keccak256(event.abi_signature()).as_slice());
+    let topics = vec![topic0, H256::from_low_u64_be(1), H256::from_low_u64_be(2)];
+    let data = encode(&[
+        Token::Int(1.into()),
+        Token::Int(2.into()),
+        Token::Uint(3u64.into()),
+        Token::Uint(4u64.into()),
+        Token::Int(5i32.into()),
+        Token::Uint(6u64.into()),
+        Token::Uint(7u64.into()),
+    ]);
+    let log = Log {
+        address: Address::zero(),
+        topics,
+        data: Bytes::from(data),
+        ..Default::default()
+    };
+    let mapped = map_logs(&[log]);
+    assert_eq!(mapped.len(), 1);
+    assert_eq!(mapped[0].event, "Swap");
+    assert_eq!(mapped[0].params.len(), 9);
+}
+


### PR DESCRIPTION
## Summary
- add new log semantics module to decode logs
- expose decoded logs via `SimulationOutcome::decoded_logs`
- test semantic decoding with Uniswap V3 swap event

## Testing
- `cargo test -p sandwich-victim`


------
https://chatgpt.com/codex/tasks/task_e_68647098835083329585d69f4dee7b2f