### PR TITLE
Add anvil install and run mempool_watch via cargo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.76-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        curl \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install anvil from Foundry
+RUN curl -L https://foundry.paradigm.xyz | bash \
+    && /root/.foundry/bin/foundryup
+
+ENV PATH="/root/.foundry/bin:${PATH}"
+
+COPY . .
+
+CMD ["cargo", "run", "-p", "sandwich-victim", "--example", "mempool_watch", "--", "ws://148.251.183.245:8546"]


### PR DESCRIPTION
## Summary
- update Dockerfile to install anvil from Foundry and run `cargo run` for the `mempool_watch` example

## Testing
- `cargo check -p sandwich-victim --example mempool_watch`
- `cargo test --all --all-targets --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686493f95528833298fa695332481a1e