### PR TITLE
Fix Dockerfile OpenSSL build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Use a newer Rust image to ensure compatibility with lock file version 4
+FROM rust:1.87-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        curl \
+        git \
+        ca-certificates \
+        openssl \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install anvil from Foundry
+RUN curl -L https://foundry.paradigm.xyz | bash \
+    && /root/.foundry/bin/foundryup
+
+ENV PATH="/root/.foundry/bin:${PATH}"
+
+COPY . .
+
+CMD ["cargo", "run", "-p", "sandwich-victim", "--example", "mempool_watch", "--", "ws://148.251.183.245:8546"]


### PR DESCRIPTION
## Summary
- add `openssl` and `libssl-dev` packages in Dockerfile so `openssl-sys` compiles
- run tests for workspace

## Testing
- `cargo check -p sandwich-victim --example mempool_watch`
- `cargo test --all --all-targets --no-run`
- `docker build -t mempool_watch_test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686493f95528833298fa695332481a1e