### PR TITLE
Add token route tracking for 1inch router

### DIFF
--- a/crates/sandwich-victim/examples/analyze_tx.rs
+++ b/crates/sandwich-victim/examples/analyze_tx.rs
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Potencial vítima: {}", result.potential_victim);
     println!("Economicamente viável: {}", result.economically_viable);
     println!("Slippage: {:.4}", result.metrics.slippage);
-    println!("Router: {:?}", result.metrics.router_name);
+    println!("Router: {:#x}", result.metrics.router_address);
     println!("Rota de tokens: {:?}", result.metrics.token_route);
     if let Some(hash) = result.simulated_tx {
         println!("Tx simulada: {hash:?}");

--- a/crates/sandwich-victim/src/detectors/clusters/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/mod.rs
@@ -3,6 +3,7 @@ pub mod uniswap_v3;
 pub mod uniswap_v4;
 pub mod smart_router;
 pub mod oneinch_generic_router;
+pub mod oneinch_aggregation_router_v6;
 pub mod uniswap_universal_router;
 
 /// Agrupamento semântico das implementações de detectores.

--- a/crates/sandwich-victim/src/detectors/clusters/oneinch_aggregation_router_v6/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/oneinch_aggregation_router_v6/mod.rs
@@ -1,0 +1,118 @@
+use crate::dex::{RouterInfo, SwapFunction};
+use crate::simulation::SimulationOutcome;
+use crate::types::{AnalysisResult, Metrics, TransactionData};
+use anyhow::Result;
+use async_trait::async_trait;
+use ethereum_types::{Address, U256};
+use ethernity_core::traits::RpcProvider;
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::sync::Arc;
+
+/// Detector para o Aggregation Router V6 da 1inch.
+pub struct OneInchAggregationRouterV6Detector;
+
+pub static AGGREGATION_ROUTER_V6_ADDRESSES: Lazy<HashSet<Address>> = Lazy::new(|| {
+    [
+        "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "0x1111111254eeb25477b68fb85ed929f73a960582",
+        "0x111111125421ca6dc452d289314280a0f8842a65",
+        "0xde9e4fe32b049f821c7f3e9802381aa470ffca73",
+    ]
+    .into_iter()
+    .map(|s| Address::from_str(s).expect("valid address"))
+    .collect()
+});
+
+#[async_trait]
+impl crate::detectors::VictimDetector for OneInchAggregationRouterV6Detector {
+    fn supports(&self, router: &RouterInfo) -> bool {
+        AGGREGATION_ROUTER_V6_ADDRESSES.contains(&router.address)
+    }
+
+    async fn analyze(
+        &self,
+        rpc_client: Arc<dyn RpcProvider>,
+        rpc_endpoint: String,
+        tx: TransactionData,
+        block: Option<u64>,
+        outcome: SimulationOutcome,
+        router: RouterInfo,
+    ) -> Result<AnalysisResult> {
+        analyze_oneinch_aggregation_router_v6(rpc_client, rpc_endpoint, tx, block, outcome, router)
+            .await
+    }
+}
+
+/// Lista de seletores de funções de swap do Aggregation Router V6.
+static SWAP_SELECTORS: Lazy<Vec<[u8; 4]>> = Lazy::new(|| {
+    use ethers::utils::id;
+    vec![
+        id("swap(address,(address,address,address,address,uint256,uint256,uint256,uint256),bytes)")[..4].try_into().unwrap(),
+        id("unoswap(address,uint256,uint256,bytes32[])")[..4].try_into().unwrap(),
+        id("unoswapTo(address,address,uint256,uint256,bytes32[])")[..4].try_into().unwrap(),
+        id("unoswapWithPermit(address,uint256,uint256,bytes32[],uint256,uint256,uint8,bytes32,bytes32)")[..4].try_into().unwrap(),
+        id("unoswapToWithPermit(address,address,uint256,uint256,bytes32[],uint256,uint256,uint8,bytes32,bytes32)")[..4].try_into().unwrap(),
+        id("uniswapV3Swap(uint256,uint256,uint256[])")[..4].try_into().unwrap(),
+        id("uniswapV3SwapTo(address,uint256,uint256,uint256[])")[..4].try_into().unwrap(),
+        id("uniswapV3SwapToWithPermit(address,uint256,uint256,uint256[],uint256,uint256,uint8,bytes32,bytes32)")[..4].try_into().unwrap(),
+        id("clipperSwap(address,address,uint256,uint256,uint256,uint256)")[..4].try_into().unwrap(),
+        // selector observed in production transactions
+        [0x07, 0xed, 0x23, 0x79],
+    ]
+});
+
+pub async fn analyze_oneinch_aggregation_router_v6(
+    _rpc_client: Arc<dyn RpcProvider>,
+    _rpc_endpoint: String,
+    tx: TransactionData,
+    _block: Option<u64>,
+    outcome: SimulationOutcome,
+    router: RouterInfo,
+) -> Result<AnalysisResult> {
+    if tx.data.len() < 4 || !SWAP_SELECTORS.iter().any(|s| tx.data[..4] == s[..]) {
+        return Err(anyhow::anyhow!("not aggregation router v6 swap"));
+    }
+
+    use ethers::utils::keccak256;
+    use ethers::types::H256;
+
+    let transfer_sig: H256 = H256::from_slice(keccak256("Transfer(address,address,uint256)").as_slice());
+    let mut src_token = Address::zero();
+    let mut dst_token = Address::zero();
+
+    for log in &outcome.logs {
+        if log.topics.get(0) == Some(&transfer_sig) && log.topics.len() == 3 {
+            let from = Address::from_slice(&log.topics[1].as_bytes()[12..]);
+            let to = Address::from_slice(&log.topics[2].as_bytes()[12..]);
+            if from == tx.from {
+                src_token = log.address;
+            }
+            if to == tx.from {
+                dst_token = log.address;
+            }
+        }
+    }
+
+    let metrics = Metrics {
+        swap_function: SwapFunction::SwapV2ExactIn,
+        token_route: if src_token != Address::zero() && dst_token != Address::zero() {
+            vec![src_token, dst_token]
+        } else {
+            Vec::new()
+        },
+        slippage: 0.0,
+        min_tokens_to_affect: U256::zero(),
+        potential_profit: U256::zero(),
+        router_address: router.address,
+        router_name: None,
+    };
+
+    Ok(AnalysisResult {
+        potential_victim: false,
+        economically_viable: false,
+        simulated_tx: None,
+        metrics,
+    })
+}

--- a/crates/sandwich-victim/src/detectors/clusters/smart_router/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/smart_router/mod.rs
@@ -2,6 +2,7 @@ use crate::detectors::clusters::uniswap_v2::analyze_uniswap_v2;
 
 pub mod custom;
 use crate::dex::{detect_swap_function, RouterInfo};
+use super::oneinch_aggregation_router_v6::AGGREGATION_ROUTER_V6_ADDRESSES;
 use crate::simulation::SimulationOutcome;
 use crate::types::{AnalysisResult, TransactionData};
 use anyhow::{anyhow, Result};
@@ -16,7 +17,7 @@ pub struct MulticallBytesDetector;
 #[async_trait]
 impl crate::detectors::VictimDetector for MulticallBytesDetector {
     fn supports(&self, router: &RouterInfo) -> bool {
-        router.factory.is_none()
+        router.factory.is_none() && !AGGREGATION_ROUTER_V6_ADDRESSES.contains(&router.address)
     }
 
     async fn analyze(

--- a/crates/sandwich-victim/src/detectors/mod.rs
+++ b/crates/sandwich-victim/src/detectors/mod.rs
@@ -13,6 +13,7 @@ use clusters::uniswap_v4::UniswapV4Detector;
 use clusters::smart_router::MulticallBytesDetector;
 use clusters::smart_router::custom::SmartRouterUniswapV3Detector;
 use clusters::oneinch_generic_router::OneInchGenericRouterDetector;
+use clusters::oneinch_aggregation_router_v6::OneInchAggregationRouterV6Detector;
 use clusters::uniswap_universal_router::UniswapUniversalRouterDetector;
 
 #[async_trait]
@@ -41,6 +42,7 @@ impl Default for DetectorRegistry {
                 Box::new(SmartRouterUniswapV3Detector),
                 Box::new(MulticallBytesDetector),
                 Box::new(OneInchGenericRouterDetector),
+                Box::new(OneInchAggregationRouterV6Detector),
                 Box::new(UniswapUniversalRouterDetector),
                 Box::new(UniswapV4Detector),
                 Box::new(UniswapV2Detector),


### PR DESCRIPTION
## Summary
- track tokens for 1inch Aggregation Router V6 swaps
- print router address instead of name in `analyze_tx` example

## Testing
- `cargo test -p sandwich-victim --lib`
- `cargo run -p sandwich-victim --example analyze_tx https://f261-2804-461c-90bf-de00-929c-7892-7fb-17f7.ngrok-free.app/ 0x90f8460c7ee89b66a926839d05e46beb2b071c892687a077ba6a94b3de9cacc5`

------
https://chatgpt.com/codex/tasks/task_e_686545b740348332a579664e9b364e19