### PR TITLE
Implement SwapV3ExactIn support

### DIFF
--- a/crates/sandwich-victim/src/detectors/clusters/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/mod.rs
@@ -35,7 +35,8 @@ impl From<&SwapFunction> for Cluster {
             SwapFunction::ExactInputSingle
             | SwapFunction::ExactInput
             | SwapFunction::ExactOutputSingle
-            | SwapFunction::ExactOutput => Cluster::UniswapV3,
+            | SwapFunction::ExactOutput
+            | SwapFunction::SwapV3ExactIn => Cluster::UniswapV3,
             SwapFunction::UniversalRouterSwap | SwapFunction::UniversalRouterSwapDeadline => {
                 Cluster::UniswapUniversalRouter
             }

--- a/crates/sandwich-victim/src/detectors/clusters/uniswap_v3/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/uniswap_v3/mod.rs
@@ -1,9 +1,13 @@
 use crate::dex::RouterInfo;
 use crate::simulation::SimulationOutcome;
-use crate::types::{AnalysisResult, TransactionData};
+use crate::types::{AnalysisResult, Metrics, TransactionData};
+use crate::core::metrics::U256Ext;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use ethernity_core::traits::RpcProvider;
+use ethers::types::H256;
+use ethers::utils::keccak256;
+use ethereum_types::{Address, U256};
 use std::sync::Arc;
 
 /// Detector para funções do Uniswap V3 Router.
@@ -19,11 +23,77 @@ impl crate::detectors::VictimDetector for UniswapV3Detector {
         &self,
         _rpc_client: Arc<dyn RpcProvider>,
         _rpc_endpoint: String,
-        _tx: TransactionData,
+        tx: TransactionData,
         _block: Option<u64>,
-        _outcome: SimulationOutcome,
-        _router: RouterInfo,
+        outcome: SimulationOutcome,
+        router: RouterInfo,
     ) -> Result<AnalysisResult> {
-        Err(anyhow!("uniswap v3 detector not implemented"))
+        const SELECTOR: [u8; 4] = [0x18, 0x61, 0xa3, 0xd8];
+        if tx.data.len() < 4 || tx.data[..4] != SELECTOR {
+            return Err(anyhow!("unsupported uniswap v3 swap"));
+        }
+        let data = &tx.data[4..];
+        if data.len() < 32 * 10 {
+            return Err(anyhow!("invalid calldata"));
+        }
+        let mut iter = data.chunks_exact(32);
+        let token_in = Address::from_slice(&iter.next().unwrap()[12..]);
+        let token_out = Address::from_slice(&iter.next().unwrap()[12..]);
+        let through1 = Address::from_slice(&iter.next().unwrap()[12..]);
+        let through2 = Address::from_slice(&iter.next().unwrap()[12..]);
+        let _fee = U256::from_big_endian(iter.next().unwrap());
+        let recipient = Address::from_slice(&iter.next().unwrap()[12..]);
+        let _deadline = U256::from_big_endian(iter.next().unwrap());
+        let _amount_in = U256::from_big_endian(iter.next().unwrap());
+        let amount_out_min = U256::from_big_endian(iter.next().unwrap());
+        let _sqrt_price_limit = U256::from_big_endian(iter.next().unwrap());
+        let kind = crate::dex::SwapFunction::SwapV3ExactIn;
+
+        let mut path = vec![token_in];
+        if through1 != Address::zero() {
+            path.push(through1);
+        }
+        if through2 != Address::zero() {
+            path.push(through2);
+        }
+        path.push(token_out);
+
+        let transfer_sig: H256 =
+            H256::from_slice(keccak256("Transfer(address,address,uint256)").as_slice());
+        let mut actual_out = U256::zero();
+        for log in &outcome.logs {
+            if log.topics.get(0) == Some(&transfer_sig) && log.topics.len() >= 3 {
+                let to_addr = Address::from_slice(&log.topics[2].as_bytes()[12..]);
+                if to_addr == recipient {
+                    actual_out = U256::from_big_endian(&log.data.0);
+                }
+            }
+        }
+        let slippage = if actual_out < amount_out_min && !amount_out_min.is_zero() {
+            (amount_out_min - actual_out).to_f64_lossy() / amount_out_min.to_f64_lossy()
+        } else {
+            0.0
+        };
+
+        let router_name = router
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("{:#x}", router.address));
+        let metrics = Metrics {
+            swap_function: kind,
+            token_route: path,
+            slippage,
+            min_tokens_to_affect: U256::zero(),
+            potential_profit: U256::zero(),
+            router_address: router.address,
+            router_name: Some(router_name),
+        };
+
+        Ok(AnalysisResult {
+            potential_victim: slippage > 0.0,
+            economically_viable: false,
+            simulated_tx: None,
+            metrics,
+        })
     }
 }

--- a/crates/sandwich-victim/src/dex/decoder.rs
+++ b/crates/sandwich-victim/src/dex/decoder.rs
@@ -19,6 +19,7 @@ pub enum SwapFunction {
     ExactOutputSingle,
     ExactOutput,
     SwapV2ExactIn,
+    SwapV3ExactIn,
     /// Any swap function of the 1inch Aggregation Router V6
     AggregationRouterV6Swap,
     /// `UniversalRouter.execute(bytes,bytes[])`
@@ -74,6 +75,9 @@ impl SwapFunction {
             }
             SwapFunction::SwapV2ExactIn => {
                 "swapV2ExactIn(address,address,uint256,uint256,address)"
+            }
+            SwapFunction::SwapV3ExactIn => {
+                "swapV3ExactIn((address,address,address,address,uint24,address,uint256,uint256,uint256,uint160))"
             }
             // Although the Aggregation Router V6 exposes many swap variants,
             // `aggregationSwap(bytes)` is used as a canonical placeholder when
@@ -167,6 +171,12 @@ pub fn detect_swap_function(data: &[u8]) -> Option<(SwapFunction, Function)> {
             .parse_function("aggregationSwap(bytes)")
             .expect("abi parse");
         return Some((SwapFunction::AggregationRouterV6Swap, f));
+    }
+    if selector == &[0x18, 0x61, 0xa3, 0xd8] {
+        let f = AbiParser::default()
+            .parse_function("swapV3ExactIn(bytes)")
+            .expect("abi parse");
+        return Some((SwapFunction::SwapV3ExactIn, f));
     }
     None
 }

--- a/crates/sandwich-victim/src/dex/router.rs
+++ b/crates/sandwich-victim/src/dex/router.rs
@@ -58,11 +58,18 @@ where
 
 /// Tenta extrair o endereço do router a partir dos logs de simulação
 pub fn router_from_logs(logs: &[Log]) -> Option<Address> {
-    let swap_sig = H256::from_slice(
-        keccak256("Swap(address,uint256,uint256,uint256,uint256,address)").as_slice(),
+    let swap_sig_v2 =
+        H256::from_slice(keccak256("Swap(address,uint256,uint256,uint256,uint256,address)").as_slice());
+    let swap_sig_v3 = H256::from_slice(
+        keccak256(
+            "Swap(address,address,int256,int256,uint160,uint128,int24,uint128,uint128)",
+        )
+        .as_slice(),
     );
     for log in logs {
-        if log.topics.get(0) == Some(&swap_sig) && log.topics.len() > 1 {
+        if log.topics.get(0) == Some(&swap_sig_v2) && log.topics.len() > 1 {
+            return Some(Address::from_slice(&log.topics[1].as_bytes()[12..]));
+        } else if log.topics.get(0) == Some(&swap_sig_v3) && log.topics.len() > 1 {
             return Some(Address::from_slice(&log.topics[1].as_bytes()[12..]));
         }
     }

--- a/crates/sandwich-victim/src/filters/mod.rs
+++ b/crates/sandwich-victim/src/filters/mod.rs
@@ -43,12 +43,18 @@ impl FilterPipeline {
 /// Filtro que verifica a presença do evento `Swap` nos logs
 pub struct SwapLogFilter;
 
-const SWAP_TOPIC: &str = "0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822";
+const SWAP_TOPIC_V2: &str = "0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822";
+const SWAP_TOPIC_V3: &str = "0x19b47279256b2a23a1665c810c8d55a1758940ee09377d4f8d26497a3577dc83";
 
 impl Filter for SwapLogFilter {
     fn apply(&self, outcome: SimulationOutcome) -> Option<SimulationOutcome> {
-        let topic = H256::from_str(SWAP_TOPIC).expect("valid topic hex");
-        if outcome.logs.iter().any(|log| log.topics.get(0) == Some(&topic)) {
+        let topic_v2 = H256::from_str(SWAP_TOPIC_V2).expect("valid topic hex");
+        let topic_v3 = H256::from_str(SWAP_TOPIC_V3).expect("valid topic hex");
+        if outcome
+            .logs
+            .iter()
+            .any(|log| log.topics.get(0) == Some(&topic_v2) || log.topics.get(0) == Some(&topic_v3))
+        {
             Some(outcome)
         } else {
             None

--- a/crates/sandwich-victim/src/filters/mod.rs
+++ b/crates/sandwich-victim/src/filters/mod.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn filter_passes_when_topic_present() {
-        let outcome = outcome_with_topics(vec![H256::from_str(SWAP_TOPIC).unwrap()]);
+        let outcome = outcome_with_topics(vec![H256::from_str(SWAP_TOPIC_V2).unwrap()]);
         let pipeline = FilterPipeline::new().push(SwapLogFilter);
         assert!(pipeline.run(outcome).is_some());
     }


### PR DESCRIPTION
## Summary
- add `SwapV3ExactIn` variant and selector detection
- implement Uniswap V3 detector for SwapV3ExactIn
- accept Uniswap V3 swap events in SwapLogFilter
- detect router from Uniswap V3 swap logs

## Testing
- `cargo check`
- `cargo run -p sandwich-victim --example analyze_tx https://f261-2804-461c-90bf-de00-929c-7892-7fb-17f7.ngrok-free.app/ 0x5f2bf3b32ccaf67de7f7fb880bfeaeb62be58b6edfe0d5905e372a9045296f9b`

------
https://chatgpt.com/codex/tasks/task_e_6865cf3bc56c8332bfe936ccccd00c0f