### PR TITLE
Implement SwapV3ExactIn detection

### DIFF
--- a/crates/sandwich-victim/src/detectors/clusters/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/mod.rs
@@ -1,10 +1,10 @@
+pub mod oneinch_aggregation_router_v6;
+pub mod oneinch_generic_router;
+pub mod smart_router;
+pub mod uniswap_universal_router;
 pub mod uniswap_v2;
 pub mod uniswap_v3;
 pub mod uniswap_v4;
-pub mod smart_router;
-pub mod oneinch_generic_router;
-pub mod oneinch_aggregation_router_v6;
-pub mod uniswap_universal_router;
 
 /// Agrupamento semântico das implementações de detectores.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,7 +35,8 @@ impl From<&SwapFunction> for Cluster {
             SwapFunction::ExactInputSingle
             | SwapFunction::ExactInput
             | SwapFunction::ExactOutputSingle
-            | SwapFunction::ExactOutput => Cluster::UniswapV3,
+            | SwapFunction::ExactOutput
+            | SwapFunction::SwapV3ExactIn => Cluster::UniswapV3,
             SwapFunction::UniversalRouterSwap | SwapFunction::UniversalRouterSwapDeadline => {
                 Cluster::UniswapUniversalRouter
             }

--- a/crates/sandwich-victim/src/detectors/clusters/uniswap_v3/mod.rs
+++ b/crates/sandwich-victim/src/detectors/clusters/uniswap_v3/mod.rs
@@ -1,8 +1,9 @@
-use crate::dex::RouterInfo;
+use crate::dex::{detect_swap_function, RouterInfo, SwapFunction};
 use crate::simulation::SimulationOutcome;
-use crate::types::{AnalysisResult, TransactionData};
+use crate::types::{AnalysisResult, Metrics, TransactionData};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use ethereum_types::{Address, U256};
 use ethernity_core::traits::RpcProvider;
 use std::sync::Arc;
 
@@ -19,11 +20,61 @@ impl crate::detectors::VictimDetector for UniswapV3Detector {
         &self,
         _rpc_client: Arc<dyn RpcProvider>,
         _rpc_endpoint: String,
-        _tx: TransactionData,
+        tx: TransactionData,
         _block: Option<u64>,
         _outcome: SimulationOutcome,
         _router: RouterInfo,
     ) -> Result<AnalysisResult> {
-        Err(anyhow!("uniswap v3 detector not implemented"))
+        let (func, f) = detect_swap_function(&tx.data).ok_or(anyhow!("unrecognized swap"))?;
+        if func != SwapFunction::SwapV3ExactIn {
+            return Err(anyhow!("unsupported swap"));
+        }
+        let tokens = f.decode_input(&tx.data[4..])?;
+        let params = tokens
+            .get(0)
+            .and_then(|t| t.clone().into_tuple())
+            .ok_or_else(|| anyhow!("invalid params"))?;
+        let token_in = params
+            .get(0)
+            .and_then(|t| t.clone().into_address())
+            .ok_or_else(|| anyhow!("tokenIn"))?;
+        let token_out = params
+            .get(1)
+            .and_then(|t| t.clone().into_address())
+            .ok_or_else(|| anyhow!("tokenOut"))?;
+        let through1 = params
+            .get(2)
+            .and_then(|t| t.clone().into_address())
+            .unwrap_or(Address::zero());
+        let through2 = params
+            .get(3)
+            .and_then(|t| t.clone().into_address())
+            .unwrap_or(Address::zero());
+
+        let mut token_route = vec![token_in];
+        if through1 != Address::zero() {
+            token_route.push(through1);
+        }
+        if through2 != Address::zero() {
+            token_route.push(through2);
+        }
+        token_route.push(token_out);
+
+        let metrics = Metrics {
+            swap_function: func,
+            token_route,
+            slippage: 0.0,
+            min_tokens_to_affect: U256::zero(),
+            potential_profit: U256::zero(),
+            router_address: tx.to,
+            router_name: Some(format!("{:#x}", tx.to)),
+        };
+
+        Ok(AnalysisResult {
+            potential_victim: true,
+            economically_viable: false,
+            simulated_tx: None,
+            metrics,
+        })
     }
 }

--- a/crates/sandwich-victim/src/dex/decoder.rs
+++ b/crates/sandwich-victim/src/dex/decoder.rs
@@ -19,6 +19,7 @@ pub enum SwapFunction {
     ExactOutputSingle,
     ExactOutput,
     SwapV2ExactIn,
+    SwapV3ExactIn,
     /// Any swap function of the 1inch Aggregation Router V6
     AggregationRouterV6Swap,
     /// `UniversalRouter.execute(bytes,bytes[])`
@@ -75,6 +76,9 @@ impl SwapFunction {
             SwapFunction::SwapV2ExactIn => {
                 "swapV2ExactIn(address,address,uint256,uint256,address)"
             }
+            SwapFunction::SwapV3ExactIn => {
+                "swapV3ExactIn((address,address,address,address,uint24,address,uint256,uint256,uint256,uint160))"
+            }
             // Although the Aggregation Router V6 exposes many swap variants,
             // `aggregationSwap(bytes)` is used as a canonical placeholder when
             // decoding fails. Use its signature here so `signature()` always
@@ -108,6 +112,10 @@ pub fn detect_swap_function(data: &[u8]) -> Option<(SwapFunction, Function)> {
         (SwapFunction::ExactOutputSingle, "exactOutputSingle((address,address,uint24,address,uint256,uint256,uint256,uint160))"),
         (SwapFunction::ExactOutput, "exactOutput((bytes,address,uint256,uint256,uint256))"),
         (SwapFunction::SwapV2ExactIn, "swapV2ExactIn(address,address,uint256,uint256,address)"),
+        (
+            SwapFunction::SwapV3ExactIn,
+            "swapV3ExactIn((address,address,address,address,uint24,address,uint256,uint256,uint256,uint160))",
+        ),
         // Uniswap Universal Router execute functions
         (
             SwapFunction::UniversalRouterSwap,


### PR DESCRIPTION
## Summary
- add `SwapV3ExactIn` to swap decoder
- classify the new swap variant in detector cluster enum
- implement detector logic for Uniswap V3 swaps with `SwapV3ExactIn`

## Testing
- `cargo test -p sandwich-victim --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6867369eb4008332aa1c30299a376e28