### PR TITLE
Improve mempool watch example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "anvil",
  "anyhow",
  "async-trait",
+ "chrono",
  "dashmap",
  "ethereum-types",
  "ethernity-core",

--- a/crates/sandwich-victim/Cargo.toml
+++ b/crates/sandwich-victim/Cargo.toml
@@ -23,6 +23,7 @@ ethernity-core = { path = "../ethernity-core" }
 ethernity-rpc = { path = "../ethernity-rpc" }
 async-trait = { workspace = true }
 once_cell = "1"
+chrono = { workspace = true }
 
 # Dependência para simulação local
 anvil = "0.3"

--- a/crates/sandwich-victim/examples/mempool_watch.rs
+++ b/crates/sandwich-victim/examples/mempool_watch.rs
@@ -1,15 +1,15 @@
 use std::env;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use chrono::Local;
+use dashmap::DashMap;
 use ethernity_rpc::{EthernityRpcClient, RpcConfig};
 use ethers::prelude::*;
 use futures::StreamExt;
 use sandwich_victim::core::analyze_transaction;
 use sandwich_victim::types::{Metrics, TransactionData};
-use std::sync::Arc;
-use chrono::Local;
-use dashmap::DashMap;
 
 #[derive(Debug, Clone)]
 struct VictimInfo {
@@ -40,82 +40,96 @@ async fn main() -> Result<()> {
 
     let victims: Arc<DashMap<H256, VictimInfo>> = Arc::new(DashMap::new());
 
-    // ---------- Mempool listener ----------
-    let mempool_provider = provider.clone();
-    let mempool_client = rpc_client.clone();
-    let mempool_victims = victims.clone();
-    let mempool_ws = ws_url.clone();
-    tokio::spawn(async move {
-        let mut stream = mempool_provider
-            .subscribe_pending_txs()
-            .await
-            .expect("failed to subscribe pending txs")
-            .transactions_unordered(10);
-        println!("Escutando transações pendentes...");
-
-        while let Some(res) = stream.next().await {
-            let tx = match res {
-                Ok(tx) => tx,
-                Err(_) => continue,
-            };
-
-            let Some(to) = tx.to else { continue };
-            let tx_data = TransactionData {
-                from: tx.from,
-                to,
-                data: tx.input.to_vec(),
-                value: tx.value,
-                gas: tx.gas.as_u64(),
-                gas_price: tx.gas_price.unwrap_or_default(),
-                nonce: tx.nonce,
-            };
-
-            if let Ok(result) = analyze_transaction(mempool_client.clone(), mempool_ws.clone(), tx_data, None).await {
-                if result.potential_victim {
-                    let detected_at = Local::now();
-                    mempool_victims.insert(
-                        tx.hash,
-                        VictimInfo { detected_at, metrics: result.metrics },
-                    );
-                    println!(
-                        "[mempool {}] possível vítima {:?}",
-                        detected_at.format("%H:%M:%S%.3f"),
-                        tx.hash
-                    );
-                }
-            }
-        }
-    });
-
-    // ---------- Block listener ----------
-    let block_provider = provider.clone();
-    let block_victims = victims.clone();
-    tokio::spawn(async move {
-        let mut blocks = block_provider
-            .subscribe_blocks()
-            .await
-            .expect("failed to subscribe blocks");
-        println!("Escutando novos blocos...");
-
-        while let Some(block) = blocks.next().await {
-            let Some(number) = block.number else { continue };
-            for hash in block.transactions {
-                if let Some((_, info)) = block_victims.remove(&hash) {
-                    println!("Tx {:?} confirmada no bloco {}", hash, number);
-                    println!(
-                        "Detectada em {}",
-                        info.detected_at.format("%H:%M:%S%.3f")
-                    );
-                    println!("Slippage: {:.4}", info.metrics.slippage);
-                    println!("Router: {:?}", info.metrics.router_name);
-                    println!("Rota de tokens: {:?}", info.metrics.token_route);
-                }
-            }
-        }
-    });
-
-    // keep running
-    futures::future::pending::<()>().await;
+    tokio::try_join!(
+        mempool_listener(provider.clone(), rpc_client.clone(), ws_url.clone(), victims.clone()),
+        block_listener(provider.clone(), victims.clone()),
+        cleanup_task(victims.clone(), Duration::from_secs(600)),
+    )?;
 
     Ok(())
+}
+
+async fn mempool_listener(
+    provider: Arc<Provider<Ws>>,
+    rpc_client: Arc<EthernityRpcClient>,
+    ws_url: String,
+    victims: Arc<DashMap<H256, VictimInfo>>,
+) -> Result<()> {
+    let mut stream = provider.subscribe_pending_txs().await?.transactions_unordered(10);
+    println!("Escutando transações pendentes...");
+
+    while let Some(res) = stream.next().await {
+        let tx = match res {
+            Ok(tx) => tx,
+            Err(err) => {
+                eprintln!("Erro ao obter transação: {err}");
+                continue;
+            }
+        };
+
+        let Some(to) = tx.to else { continue };
+        let tx_data = TransactionData {
+            from: tx.from,
+            to,
+            data: tx.input.to_vec(),
+            value: tx.value,
+            gas: tx.gas.as_u64(),
+            gas_price: tx.gas_price.unwrap_or_default(),
+            nonce: tx.nonce,
+        };
+
+        if let Ok(result) = analyze_transaction(rpc_client.clone(), ws_url.clone(), tx_data, None).await {
+            if result.potential_victim {
+                let detected_at = Local::now();
+                victims.insert(
+                    tx.hash,
+                    VictimInfo { detected_at, metrics: result.metrics },
+                );
+                println!(
+                    "[mempool {}] possível vítima {:?}",
+                    detected_at.format("%H:%M:%S%.3f"),
+                    tx.hash
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn block_listener(
+    provider: Arc<Provider<Ws>>,
+    victims: Arc<DashMap<H256, VictimInfo>>,
+) -> Result<()> {
+    let mut blocks = provider.subscribe_blocks().await?;
+    println!("Escutando novos blocos...");
+
+    while let Some(block) = blocks.next().await {
+        let Some(number) = block.number else { continue };
+        for hash in block.transactions {
+            if let Some((_, info)) = victims.remove(&hash) {
+                println!("Tx {:?} confirmada no bloco {}", hash, number);
+                println!(
+                    "Detectada em {}",
+                    info.detected_at.format("%H:%M:%S%.3f")
+                );
+                println!("Slippage: {:.4}", info.metrics.slippage);
+                println!("Router: {:?}", info.metrics.router_name);
+                println!("Rota de tokens: {:?}", info.metrics.token_route);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cleanup_task(
+    victims: Arc<DashMap<H256, VictimInfo>>,
+    ttl: Duration,
+) -> Result<()> {
+    let mut interval = tokio::time::interval(ttl);
+    loop {
+        interval.tick().await;
+        let now = Local::now();
+        let max_age = chrono::Duration::from_std(ttl).unwrap();
+        victims.retain(|_, info| now - info.detected_at <= max_age);
+    }
 }


### PR DESCRIPTION
## Summary
- track pending transactions with timestamp and metrics
- sync with blocks to display inclusion information
- add chrono to sandwich-victim

## Testing
- `cargo check -p sandwich-victim --example mempool_watch`

------
https://chatgpt.com/codex/tasks/task_e_68681316c1d0833280be7da8e51b140a