### PR TITLE
Simplify mempool watch example

### DIFF
--- a/crates/sandwich-victim/examples/README.md
+++ b/crates/sandwich-victim/examples/README.md
@@ -18,6 +18,8 @@ O programa obtém os dados da transação e a executa em um fork local com o
 
 Este exemplo conecta-se a um endpoint RPC WebSocket e escuta as transações pendentes do mempool. Cada transação é analisada e, se houver indícios de que seja uma potencial vítima de *sandwich*, as métricas são exibidas no console.
 
+O exemplo foi simplificado e **não monitora a inclusão em blocos**. O foco é detectar oportunidades assim que as transações surgem no mempool.
+
 ```bash
 cargo run -p sandwich-victim --example mempool_watch -- <WS_RPC_ENDPOINT>
 ```


### PR DESCRIPTION
## Summary
- remove block and cleanup logic from `mempool_watch` example
- clarify in the README that the example focuses only on pending transactions

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6870217077688330bc052531cf99862c