### PR TITLE
Add ethernity-simulate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1065,6 +1065,19 @@ dependencies = [
  "tracing-subscriber",
  "web3",
  "wiremock",
+]
+
+[[package]]
+name = "ethernity-simulate"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dashmap",
+ "ethers",
+ "parking_lot",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4399,6 +4412,17 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.16",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/ethernity-rpc",
     "crates/ethernity-finder",
     "crates/sandwich-victim",
+    "crates/ethernity-simulate",
 ]
 
 [workspace.package]

--- a/crates/ethernity-simulate/Cargo.toml
+++ b/crates/ethernity-simulate/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ethernity-simulate"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Simulação de transações em forks da blockchain via Anvil"
+license.workspace = true
+
+[dependencies]
+tokio = { workspace = true }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+ethers = { workspace = true }
+dashmap = { workspace = true }
+parking_lot = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+

--- a/crates/ethernity-simulate/README.md
+++ b/crates/ethernity-simulate/README.md
@@ -1,0 +1,10 @@
+# ethernity-simulate
+
+Crate responsável por criar e gerenciar ambientes de simulação de transações em forks da blockchain.
+
+A implementação inicial utiliza o **Anvil** para spawnar forks locais, mas a arquitetura foi preparada para aceitar novos provedores de simulação no futuro.
+
+Principais funcionalidades:
+- Criação de sessões de fork baseadas em um RPC remoto e bloco específico.
+- Envio de transações simuladas e obtenção do `TransactionReceipt`.
+- Encerramento manual das sessões e limpeza automática por timeout.

--- a/crates/ethernity-simulate/src/errors.rs
+++ b/crates/ethernity-simulate/src/errors.rs
@@ -1,0 +1,24 @@
+use thiserror::Error;
+
+/// Erros que podem ocorrer durante a simulação
+#[derive(Debug, Error)]
+pub enum SimulationError {
+    /// Falha ao iniciar o processo do Anvil
+    #[error("falha ao iniciar anvil: {0}")]
+    AnvilSpawn(String),
+
+    /// Falha ao criar provider conectado ao Anvil
+    #[error("falha ao criar provider do anvil: {0}")]
+    ProviderCreation(String),
+
+    /// Erro ao enviar transação
+    #[error("falha ao enviar transação: {0}")]
+    SendTransaction(String),
+
+    /// Erro ao aguardar resultado da transação
+    #[error("falha ao aguardar transação: {0}")]
+    AwaitTransaction(String),
+}
+
+/// Resultado padrão da crate
+pub type Result<T> = std::result::Result<T, SimulationError>;

--- a/crates/ethernity-simulate/src/lib.rs
+++ b/crates/ethernity-simulate/src/lib.rs
@@ -1,0 +1,15 @@
+/*! ethernity-simulate
+ *
+ * Crate para simulação de transações em forks Ethereum.
+ * Inicialmente utiliza o Anvil como backend para criação de forks locais.
+ */
+
+pub mod errors;
+pub mod traits;
+pub mod providers;
+pub mod sessions;
+
+pub use errors::*;
+pub use traits::*;
+pub use providers::*;
+pub use sessions::*;

--- a/crates/ethernity-simulate/src/providers/anvil.rs
+++ b/crates/ethernity-simulate/src/providers/anvil.rs
@@ -1,0 +1,75 @@
+use std::time::{Duration, Instant};
+
+use ethers::utils::{Anvil, AnvilInstance};
+use ethers::providers::{Provider, Http, Middleware};
+use ethers::types::{TransactionReceipt, transaction::eip2718::TypedTransaction};
+use tokio::sync::Mutex;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::{errors::{Result, SimulationError}, traits::{SimulationProvider, SimulationSession}};
+
+/// Sessão de simulação utilizando o Anvil
+pub struct AnvilSession {
+    pub id: Uuid,
+    provider: Provider<Http>,
+    _anvil: AnvilInstance,
+    created: Instant,
+    timeout: Duration,
+}
+
+impl AnvilSession {
+    fn expired(&self) -> bool {
+        self.created.elapsed() > self.timeout
+    }
+}
+
+#[async_trait]
+impl SimulationSession for Mutex<AnvilSession> {
+    async fn send_transaction(&self, tx: &TypedTransaction) -> Result<TransactionReceipt> {
+        let provider = {
+            let mut guard = self.lock().await;
+            guard.created = Instant::now();
+            guard.provider.clone()
+        };
+        let pending = provider
+            .send_transaction(tx.clone(), None)
+            .await
+            .map_err(|e| SimulationError::SendTransaction(e.to_string()))?;
+        let receipt = pending
+            .await
+            .map_err(|e| SimulationError::AwaitTransaction(e.to_string()))?
+            .ok_or_else(|| SimulationError::AwaitTransaction("sem recibo".into()))?;
+        Ok(receipt)
+    }
+
+    async fn close(&self) {
+        let _ = self.lock().await;
+    }
+}
+
+pub struct AnvilProvider;
+
+#[async_trait]
+impl SimulationProvider for AnvilProvider {
+    type Session = Mutex<AnvilSession>;
+
+    async fn create_session(&self, rpc_url: &str, block_number: u64, timeout: Duration) -> Result<Self::Session> {
+        let anvil = Anvil::new()
+            .fork(rpc_url)
+            .fork_block_number(block_number)
+            .spawn();
+
+        let provider = Provider::<Http>::try_from(anvil.endpoint())
+            .map_err(|e| SimulationError::ProviderCreation(e.to_string()))?
+            .interval(Duration::from_millis(1));
+
+        Ok(Mutex::new(AnvilSession {
+            id: Uuid::new_v4(),
+            provider,
+            _anvil: anvil,
+            created: Instant::now(),
+            timeout,
+        }))
+    }
+}

--- a/crates/ethernity-simulate/src/providers/mod.rs
+++ b/crates/ethernity-simulate/src/providers/mod.rs
@@ -1,0 +1,3 @@
+pub mod anvil;
+
+pub use anvil::{AnvilProvider, AnvilSession};

--- a/crates/ethernity-simulate/src/sessions/mod.rs
+++ b/crates/ethernity-simulate/src/sessions/mod.rs
@@ -1,0 +1,3 @@
+mod session;
+
+pub use session::{SessionEntry, SessionManager};

--- a/crates/ethernity-simulate/src/sessions/session.rs
+++ b/crates/ethernity-simulate/src/sessions/session.rs
@@ -1,0 +1,51 @@
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+use dashmap::DashMap;
+use std::sync::Arc;
+
+use crate::traits::SimulationSession;
+
+/// Estrutura interna de controle de sessão
+pub struct SessionEntry<S: SimulationSession> {
+    pub id: Uuid,
+    pub session: Arc<S>,
+    pub created: Instant,
+    pub timeout: Duration,
+}
+
+impl<S: SimulationSession> SessionEntry<S> {
+    pub fn expired(&self) -> bool {
+        self.created.elapsed() > self.timeout
+    }
+}
+
+/// Gerenciador de sessões
+pub struct SessionManager<S: SimulationSession> {
+    sessions: DashMap<Uuid, SessionEntry<S>>,
+}
+
+impl<S: SimulationSession> SessionManager<S> {
+    pub fn new() -> Self {
+        Self { sessions: DashMap::new() }
+    }
+
+    pub fn insert(&self, session: Arc<S>, timeout: Duration) -> Uuid {
+        let id = Uuid::new_v4();
+        self.sessions.insert(id, SessionEntry { id, session, created: Instant::now(), timeout });
+        id
+    }
+
+    pub fn get(&self, id: &Uuid) -> Option<Arc<S>> {
+        self.cleanup();
+        self.sessions.get(id).map(|e| e.session.clone())
+    }
+
+    pub fn remove(&self, id: &Uuid) {
+        self.sessions.remove(id);
+    }
+
+    fn cleanup(&self) {
+        let now = Instant::now();
+        self.sessions.retain(|_, v| now.duration_since(v.created) < v.timeout);
+    }
+}

--- a/crates/ethernity-simulate/src/traits.rs
+++ b/crates/ethernity-simulate/src/traits.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+use ethers::types::{TransactionReceipt, transaction::eip2718::TypedTransaction};
+use std::time::Duration;
+
+use crate::errors::Result;
+
+#[async_trait]
+pub trait SimulationSession: Send + Sync {
+    /// Envia uma transação para a sessão simulada
+    async fn send_transaction(&self, tx: &TypedTransaction) -> Result<TransactionReceipt>;
+
+    /// Encerra a sessão
+    async fn close(&self);
+}
+
+#[async_trait]
+pub trait SimulationProvider: Send + Sync {
+    type Session: SimulationSession;
+
+    /// Cria uma nova sessão de simulação
+    async fn create_session(&self, rpc_url: &str, block_number: u64, timeout: Duration) -> Result<Self::Session>;
+}


### PR DESCRIPTION
## Summary
- introduce new `ethernity-simulate` crate
- implement Anvil based simulation provider
- provide session management utilities
- update workspace configuration

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6871687ed4ec8332bca5054e44e42f91