### PR TITLE
Fix simulate example

### DIFF
--- a/crates/ethernity-simulate/examples/simulate_tx.rs
+++ b/crates/ethernity-simulate/examples/simulate_tx.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<()> {
 
     let sim_provider = AnvilProvider;
     let session = sim_provider
-        .create_session(rpc, block.as_u64(), Duration::from_secs(60))
+        .create_session(rpc, Some(block.as_u64()), Duration::from_secs(60))
         .await
         .context("falha ao criar sessao")?;
     let id = { session.lock().await.id };


### PR DESCRIPTION
## Summary
- fix the `simulate_tx` example to pass a block as `Some` for `create_session`

## Testing
- `cargo check -p ethernity-simulate --example simulate_tx`

------
https://chatgpt.com/codex/tasks/task_e_6871c3c444e483329e98cdcb8a056645