### PR TITLE
Fix simulate_tx session block

### DIFF
--- a/crates/ethernity-simulate/examples/README.md
+++ b/crates/ethernity-simulate/examples/README.md
@@ -16,6 +16,6 @@ Simula uma transação existente obtida via hash. Aceita tanto endpoints HTTP qu
 cargo run --example simulate_tx -- <RPC_ENDPOINT> <TX_HASH>
 ```
 
-O exemplo conecta-se ao endpoint informado, recupera a transação e executa a simulação em uma sessão baseada no bloco da própria transação, exibindo o tempo total gasto.
+O exemplo conecta-se ao endpoint informado, recupera a transação e executa a simulação em uma sessão iniciada no bloco **anterior** ao da transação, exibindo o tempo total gasto.
 =======
 Substitua `<RPC_WS_ENDPOINT>` pelo endereço RPC desejado (por exemplo, wss://mainnet.infura.io/ws/v3/YOUR_KEY). O `anvil` é iniciado com `--auto-impersonate` e o bloco inicial pode ser ajustado diretamente no exemplo.

--- a/crates/ethernity-simulate/examples/simulate_tx.rs
+++ b/crates/ethernity-simulate/examples/simulate_tx.rs
@@ -88,12 +88,13 @@ async fn main() -> Result<()> {
 
     let block = tx.block_number.context("transacao pendente")?;
     info!("Transacao localizada no bloco {}", block);
+    let fork_block = block.as_u64().saturating_sub(1);
 
     let start = Instant::now();
 
     let sim_provider = AnvilProvider;
     let session = sim_provider
-        .create_session(rpc, Some(block.as_u64()), Duration::from_secs(60))
+        .create_session(rpc, Some(fork_block), Duration::from_secs(60))
         .await
         .context("falha ao criar sessao")?;
     let id = { session.lock().await.id };


### PR DESCRIPTION
## Summary
- fork one block before the transaction when simulating
- clarify README instructions

## Testing
- `cargo check -p ethernity-simulate --examples`

------
https://chatgpt.com/codex/tasks/task_e_687292c89fc483309a6a1607c993fc31