### PR TITLE
Add ethernity-logs crate for Elasticsearch logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethernity-logs"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "wiremock",
+]
+
+[[package]]
 name = "ethernity-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "crates/ethernity-rpc",
     "crates/ethernity-finder",
     "crates/sandwich-victim",
-    "crates/ethernity-simulate",
+    "crates/ethernity-simulate", "crates/ethernity-logs",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ O Ethernity é um workspace Rust para interação e análise avançada de transa
 - Detectores especializados para diferentes tipos de eventos
 - Gerenciamento avançado de memória
 
+### 📝 [ethernity-logs](./crates/ethernity-logs/)
+**Envio padronizado de logs**
+- API simples para registrar logs em um endpoint Elasticsearch
+- Padroniza nível, mensagem e crate de origem
+
 
 ## Fluxo de Dados
 

--- a/crates/ethernity-logs/Cargo.toml
+++ b/crates/ethernity-logs/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ethernity-logs"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+reqwest = { version = "0.11.18", features = ["json"] }
+serde = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+
+[features]
+default = ["tokio"]
+
+[dev-dependencies]
+wiremock = "0.5"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/ethernity-logs/README.md
+++ b/crates/ethernity-logs/README.md
@@ -1,0 +1,7 @@
+# ethernity-logs
+
+Crate simples para envio de logs diretamente ao Elasticsearch.
+
+Esta biblioteca fornece uma API minimalista para padronizar a forma como
+as demais crates do projeto enviam logs. Cada log contém nível, mensagem
+textual e o nome da crate que o produziu.

--- a/crates/ethernity-logs/src/lib.rs
+++ b/crates/ethernity-logs/src/lib.rs
@@ -1,0 +1,79 @@
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde::Serialize;
+use thiserror::Error;
+
+/// Tipo de erro retornado pelo logger.
+#[derive(Debug, Error)]
+pub enum LogError {
+    #[error("erro ao enviar log: {0}")]
+    Request(#[from] reqwest::Error),
+}
+
+/// Estrutura de log enviada para o Elasticsearch.
+#[derive(Serialize)]
+struct LogEntry<'a> {
+    level: &'a str,
+    message: &'a str,
+    crate_name: &'a str,
+    timestamp: DateTime<Utc>,
+}
+
+/// Cliente simples para envio de logs ao Elasticsearch.
+pub struct EthernityLogger {
+    endpoint: String,
+    client: Client,
+}
+
+impl EthernityLogger {
+    /// Cria uma nova instância apontando para a `endpoint` do Elasticsearch.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            client: Client::new(),
+        }
+    }
+
+    /// Envia um log para o Elasticsearch.
+    pub async fn log(
+        &self,
+        level: &str,
+        message: &str,
+        crate_name: &str,
+    ) -> Result<(), LogError> {
+        let entry = LogEntry {
+            level,
+            message,
+            crate_name,
+            timestamp: Utc::now(),
+        };
+        self.client
+            .post(&self.endpoint)
+            .json(&entry)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use wiremock::matchers::{method, path};
+
+    #[tokio::test]
+    async fn send_log_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let logger = EthernityLogger::new(server.uri());
+        let result = logger.log("info", "test", "crate").await;
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ethernity-logs` crate
- update workspace to include the crate
- document the crate in the workspace README

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_687300ad5ef8833096e8bb135f1cd62b